### PR TITLE
fix: Restore activation language in SKILL.md description

### DIFF
--- a/planning-with-files/SKILL.md
+++ b/planning-with-files/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: planning-with-files
 version: "2.2.1"
-description: Implements Manus-style file-based planning for complex tasks. Creates task_plan.md, findings.md, and progress.md. Now with automatic session recovery after /clear.
+description: Implements Manus-style file-based planning for complex tasks. Creates task_plan.md, findings.md, and progress.md. Use when starting complex multi-step tasks, research projects, or any task requiring >5 tool calls. Now with automatic session recovery after /clear.
 user-invocable: true
 allowed-tools:
   - Read

--- a/skills/planning-with-files/SKILL.md
+++ b/skills/planning-with-files/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: planning-with-files
 version: "2.2.1"
-description: Implements Manus-style file-based planning for complex tasks. Creates task_plan.md, findings.md, and progress.md. Now with automatic session recovery after /clear.
+description: Implements Manus-style file-based planning for complex tasks. Creates task_plan.md, findings.md, and progress.md. Use when starting complex multi-step tasks, research projects, or any task requiring >5 tool calls. Now with automatic session recovery after /clear.
 user-invocable: true
 allowed-tools:
   - Read


### PR DESCRIPTION
## Summary

  The v2.2.1 merge accidentally removed the important activation trigger from the SKILL.md description.

  ## The Issue

  **Before (v2.1.2):**
  description: ...Creates task_plan.md, findings.md, and progress.md. Use when starting complex multi-step tasks, research projects, or any task requiring >5 tool calls.

  **After merge (v2.2.1):**
  description: ...Creates task_plan.md, findings.md, and progress.md. Now with automatic session recovery after /clear.

  The activation language "Use when starting complex multi-step tasks, research projects, or any task requiring >5 tool calls." was replaced instead of appended.

  ## The Fix

  Restored the full description:
  description: ...Creates task_plan.md, findings.md, and progress.md. Use when starting complex multi-step tasks, research projects, or any task requiring >5 tool calls. Now with automatic session recovery after /clear.

  ## Why It Matters

  This language helps Claude auto-activate the skill when it detects appropriate tasks (>5 tool calls, research, multi-step work).

  ## Files Changed

  - `skills/planning-with-files/SKILL.md`
  - `planning-with-files/SKILL.md`