### PR TITLE
Add the start command

### DIFF
--- a/commands/start.md
+++ b/commands/start.md
@@ -1,0 +1,6 @@
+---
+description: "Implements Manus-style file-based planning for complex tasks. Creates task_plan.md, findings.md, and progress.md. Use when starting complex multi-step tasks, research projects, or any task requiring >5 tool calls. Now with automatic session recovery after /clear"
+disable-model-invocation: true
+---
+
+Invoke the planning-with-files:planning-with-files skill and follow it exactly as presented to you


### PR DESCRIPTION
- Add the start command, which can be used through /planning-with-files:start in claudecode without the need to copy skills
- Copying skills to .claude/skills can also lead to ${CLAUDE-PLUGN_ROOT} path errors