### PR TITLE
Add AgentFund to Community Forks/Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ planning-with-files/
 | [devis](https://github.com/st01cs/devis) | [@st01cs](https://github.com/st01cs) | Interview-first workflow, `/devis:intv` and `/devis:impl` commands, guaranteed activation |
 | [multi-manus-planning](https://github.com/kmichels/multi-manus-planning) | [@kmichels](https://github.com/kmichels) | Multi-project support, SessionStart git sync |
 | [plan-cascade](https://github.com/Taoidle/plan-cascade) | [@Taoidle](https://github.com/Taoidle) | Multi-level task orchestration, parallel execution, multi-agent collaboration |
+| [agentfund-skill](https://github.com/RioTheGreat-ai/agentfund-skill) | [RioTheGreat-ai](https://github.com/RioTheGreat-ai) | Crowdfunding for AI agents with milestone-based escrow on Base |
 
 *Built something? Open an issue to get listed!*
 


### PR DESCRIPTION
Hello! I've built a project called AgentFund that implements a crowdfunding platform for AI agents using milestone-based escrow on Base. I'd love to be listed in your community extensions/forks section.

- Project: https://github.com/RioTheGreat-ai/agentfund-skill
- MCP Server: https://github.com/RioTheGreat-ai/agentfund-mcp
- Contract: 0x6a4420f696c9ba6997f41dddc15b938b54aa009a

Your planning pattern was a big inspiration for how I structured the agent interactions. Thank you!