### PR TITLE
feat: add /plan:status command for quick progress check

### DIFF
--- a/commands/status.md
+++ b/commands/status.md
@@ -1,0 +1,49 @@
+---
+description: "Show current planning status at a glance - phases, progress, and any logged errors."
+---
+
+Read task_plan.md from the current project directory and display a compact status summary.
+
+## What to Show
+
+1. **Current Phase**: Extract from "## Current Phase" section
+2. **Phase Progress**: Count phases and their status (pending/in_progress/complete)
+3. **Phase List**: Show each phase with status icon
+4. **Errors**: Count entries in "## Errors Encountered" table if present
+5. **Files Check**: Confirm which planning files exist
+
+## Status Icons
+
+- `[ ]` or "pending" → ⏸️
+- "in_progress" → 🔄
+- `[x]` or "complete" → ✅
+- "failed" or "blocked" → ❌
+
+## Output Format
+
+```
+📋 Planning Status
+
+Current: Phase {N} of {total} ({percent}%)
+Status: {status_icon} {status_text}
+
+  {icon} Phase 1: {name}
+  {icon} Phase 2: {name} ← you are here
+  {icon} Phase 3: {name}
+  ...
+
+Files: task_plan.md {✓|✗} | findings.md {✓|✗} | progress.md {✓|✗}
+Errors logged: {count}
+```
+
+## If No Planning Files Exist
+
+```
+📋 No planning files found
+
+Run /plan to start a new planning session.
+```
+
+## Keep It Brief
+
+This is a quick status check, not a full report. Show just enough to answer "where am I?" without re-reading all the files.


### PR DESCRIPTION
## Summary

Adds a `/plan:status` command that displays planning progress at a glance - no need to read through all planning files just to see where you are.

## The Problem

When using file-based planning, checking your current status requires reading `task_plan.md` and parsing it mentally. For a quick "where am I?" check, this is more friction than necessary.

## The Solution

A new `/plan:status` command that outputs a compact summary:

```
📋 Planning Status

Current: Phase 2 of 5 (40%)
Status: 🔄 in_progress

  ✅ Phase 1: Requirements & Discovery
  🔄 Phase 2: Planning & Structure ← you are here
  ⏸️ Phase 3: Implementation
  ⏸️ Phase 4: Testing & Verification
  ⏸️ Phase 5: Delivery

Files: task_plan.md ✓ | findings.md ✓ | progress.md ✓
Errors logged: 2
```

## What's Included

- `commands/status.md` - Command definition with output format specification
- Status icons for different states (pending, in_progress, complete, failed/blocked)
- Graceful handling when no planning files exist

## Why This Helps

- **Quick orientation** - See where you are without context switching
- **Error awareness** - Know if there are logged errors at a glance
- **File verification** - Confirm which planning files exist
- **Low cognitive load** - Visual icons make status immediately clear

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)