### PR TITLE
Add isolated .planning plan sessions with UUID + PLAN_ID pinning

### DIFF
--- a/.adal/skills/planning-with-files/scripts/session-catchup.py
+++ b/.adal/skills/planning-with-files/scripts/session-catchup.py
@@ -146,6 +146,9 @@ def main():
     has_planning_files = any(
         Path(project_path, f).exists() for f in PLANNING_FILES
     )
+    if not has_planning_files:
+        # No planning files in this project; skip catchup to avoid noise.
+        return
 
     if not project_dir.exists():
         # No previous sessions, nothing to catch up on
@@ -168,11 +171,12 @@ def main():
     messages = parse_session_messages(target_session)
     last_update_line, last_update_file = find_last_planning_update(messages)
 
-    # Only output if there's unsynced content
+    # No planning updates in the target session; skip catchup output.
     if last_update_line < 0:
-        messages_after = extract_messages_after(messages, len(messages) - 30)
-    else:
-        messages_after = extract_messages_after(messages, last_update_line)
+        return
+
+    # Only output if there's unsynced content
+    messages_after = extract_messages_after(messages, last_update_line)
 
     if not messages_after:
         return
@@ -181,11 +185,8 @@ def main():
     print("\n[planning-with-files] SESSION CATCHUP DETECTED")
     print(f"Previous session: {target_session.stem}")
 
-    if last_update_line >= 0:
-        print(f"Last planning update: {last_update_file} at message #{last_update_line}")
-        print(f"Unsynced messages: {len(messages_after)}")
-    else:
-        print("No planning file updates found in previous session")
+    print(f"Last planning update: {last_update_file} at message #{last_update_line}")
+    print(f"Unsynced messages: {len(messages_after)}")
 
     print("\n--- UNSYNCED CONTEXT ---")
     for msg in messages_after[-15:]:  # Last 15 messages

--- a/.codebuddy/skills/planning-with-files/scripts/session-catchup.py
+++ b/.codebuddy/skills/planning-with-files/scripts/session-catchup.py
@@ -146,6 +146,9 @@ def main():
     has_planning_files = any(
         Path(project_path, f).exists() for f in PLANNING_FILES
     )
+    if not has_planning_files:
+        # No planning files in this project; skip catchup to avoid noise.
+        return
 
     if not project_dir.exists():
         # No previous sessions, nothing to catch up on
@@ -168,11 +171,12 @@ def main():
     messages = parse_session_messages(target_session)
     last_update_line, last_update_file = find_last_planning_update(messages)
 
-    # Only output if there's unsynced content
+    # No planning updates in the target session; skip catchup output.
     if last_update_line < 0:
-        messages_after = extract_messages_after(messages, len(messages) - 30)
-    else:
-        messages_after = extract_messages_after(messages, last_update_line)
+        return
+
+    # Only output if there's unsynced content
+    messages_after = extract_messages_after(messages, last_update_line)
 
     if not messages_after:
         return
@@ -181,11 +185,8 @@ def main():
     print("\n[planning-with-files] SESSION CATCHUP DETECTED")
     print(f"Previous session: {target_session.stem}")
 
-    if last_update_line >= 0:
-        print(f"Last planning update: {last_update_file} at message #{last_update_line}")
-        print(f"Unsynced messages: {len(messages_after)}")
-    else:
-        print("No planning file updates found in previous session")
+    print(f"Last planning update: {last_update_file} at message #{last_update_line}")
+    print(f"Unsynced messages: {len(messages_after)}")
 
     print("\n--- UNSYNCED CONTEXT ---")
     for msg in messages_after[-15:]:  # Last 15 messages

--- a/.codex/skills/planning-with-files/scripts/session-catchup.py
+++ b/.codex/skills/planning-with-files/scripts/session-catchup.py
@@ -146,6 +146,9 @@ def main():
     has_planning_files = any(
         Path(project_path, f).exists() for f in PLANNING_FILES
     )
+    if not has_planning_files:
+        # No planning files in this project; skip catchup to avoid noise.
+        return
 
     if not project_dir.exists():
         # No previous sessions, nothing to catch up on
@@ -168,11 +171,12 @@ def main():
     messages = parse_session_messages(target_session)
     last_update_line, last_update_file = find_last_planning_update(messages)
 
-    # Only output if there's unsynced content
+    # No planning updates in the target session; skip catchup output.
     if last_update_line < 0:
-        messages_after = extract_messages_after(messages, len(messages) - 30)
-    else:
-        messages_after = extract_messages_after(messages, last_update_line)
+        return
+
+    # Only output if there's unsynced content
+    messages_after = extract_messages_after(messages, last_update_line)
 
     if not messages_after:
         return
@@ -181,11 +185,8 @@ def main():
     print("\n[planning-with-files] SESSION CATCHUP DETECTED")
     print(f"Previous session: {target_session.stem}")
 
-    if last_update_line >= 0:
-        print(f"Last planning update: {last_update_file} at message #{last_update_line}")
-        print(f"Unsynced messages: {len(messages_after)}")
-    else:
-        print("No planning file updates found in previous session")
+    print(f"Last planning update: {last_update_file} at message #{last_update_line}")
+    print(f"Unsynced messages: {len(messages_after)}")
 
     print("\n--- UNSYNCED CONTEXT ---")
     for msg in messages_after[-15:]:  # Last 15 messages

--- a/.continue/skills/planning-with-files/scripts/session-catchup.py
+++ b/.continue/skills/planning-with-files/scripts/session-catchup.py
@@ -146,6 +146,9 @@ def main():
     has_planning_files = any(
         Path(project_path, f).exists() for f in PLANNING_FILES
     )
+    if not has_planning_files:
+        # No planning files in this project; skip catchup to avoid noise.
+        return
 
     if not project_dir.exists():
         # No previous sessions, nothing to catch up on
@@ -168,11 +171,12 @@ def main():
     messages = parse_session_messages(target_session)
     last_update_line, last_update_file = find_last_planning_update(messages)
 
-    # Only output if there's unsynced content
+    # No planning updates in the target session; skip catchup output.
     if last_update_line < 0:
-        messages_after = extract_messages_after(messages, len(messages) - 30)
-    else:
-        messages_after = extract_messages_after(messages, last_update_line)
+        return
+
+    # Only output if there's unsynced content
+    messages_after = extract_messages_after(messages, last_update_line)
 
     if not messages_after:
         return
@@ -181,11 +185,8 @@ def main():
     print("\n[planning-with-files] SESSION CATCHUP DETECTED")
     print(f"Previous session: {target_session.stem}")
 
-    if last_update_line >= 0:
-        print(f"Last planning update: {last_update_file} at message #{last_update_line}")
-        print(f"Unsynced messages: {len(messages_after)}")
-    else:
-        print("No planning file updates found in previous session")
+    print(f"Last planning update: {last_update_file} at message #{last_update_line}")
+    print(f"Unsynced messages: {len(messages_after)}")
 
     print("\n--- UNSYNCED CONTEXT ---")
     for msg in messages_after[-15:]:  # Last 15 messages

--- a/.gemini/skills/planning-with-files/scripts/session-catchup.py
+++ b/.gemini/skills/planning-with-files/scripts/session-catchup.py
@@ -146,6 +146,9 @@ def main():
     has_planning_files = any(
         Path(project_path, f).exists() for f in PLANNING_FILES
     )
+    if not has_planning_files:
+        # No planning files in this project; skip catchup to avoid noise.
+        return
 
     if not project_dir.exists():
         # No previous sessions, nothing to catch up on
@@ -168,11 +171,12 @@ def main():
     messages = parse_session_messages(target_session)
     last_update_line, last_update_file = find_last_planning_update(messages)
 
-    # Only output if there's unsynced content
+    # No planning updates in the target session; skip catchup output.
     if last_update_line < 0:
-        messages_after = extract_messages_after(messages, len(messages) - 30)
-    else:
-        messages_after = extract_messages_after(messages, last_update_line)
+        return
+
+    # Only output if there's unsynced content
+    messages_after = extract_messages_after(messages, last_update_line)
 
     if not messages_after:
         return
@@ -181,11 +185,8 @@ def main():
     print("\n[planning-with-files] SESSION CATCHUP DETECTED")
     print(f"Previous session: {target_session.stem}")
 
-    if last_update_line >= 0:
-        print(f"Last planning update: {last_update_file} at message #{last_update_line}")
-        print(f"Unsynced messages: {len(messages_after)}")
-    else:
-        print("No planning file updates found in previous session")
+    print(f"Last planning update: {last_update_file} at message #{last_update_line}")
+    print(f"Unsynced messages: {len(messages_after)}")
 
     print("\n--- UNSYNCED CONTEXT ---")
     for msg in messages_after[-15:]:  # Last 15 messages

--- a/.openclaw/skills/planning-with-files/scripts/session-catchup.py
+++ b/.openclaw/skills/planning-with-files/scripts/session-catchup.py
@@ -146,6 +146,9 @@ def main():
     has_planning_files = any(
         Path(project_path, f).exists() for f in PLANNING_FILES
     )
+    if not has_planning_files:
+        # No planning files in this project; skip catchup to avoid noise.
+        return
 
     if not project_dir.exists():
         # No previous sessions, nothing to catch up on
@@ -168,11 +171,12 @@ def main():
     messages = parse_session_messages(target_session)
     last_update_line, last_update_file = find_last_planning_update(messages)
 
-    # Only output if there's unsynced content
+    # No planning updates in the target session; skip catchup output.
     if last_update_line < 0:
-        messages_after = extract_messages_after(messages, len(messages) - 30)
-    else:
-        messages_after = extract_messages_after(messages, last_update_line)
+        return
+
+    # Only output if there's unsynced content
+    messages_after = extract_messages_after(messages, last_update_line)
 
     if not messages_after:
         return
@@ -181,11 +185,8 @@ def main():
     print("\n[planning-with-files] SESSION CATCHUP DETECTED")
     print(f"Previous session: {target_session.stem}")
 
-    if last_update_line >= 0:
-        print(f"Last planning update: {last_update_file} at message #{last_update_line}")
-        print(f"Unsynced messages: {len(messages_after)}")
-    else:
-        print("No planning file updates found in previous session")
+    print(f"Last planning update: {last_update_file} at message #{last_update_line}")
+    print(f"Unsynced messages: {len(messages_after)}")
 
     print("\n--- UNSYNCED CONTEXT ---")
     for msg in messages_after[-15:]:  # Last 15 messages

--- a/.opencode/skills/planning-with-files/scripts/session-catchup.py
+++ b/.opencode/skills/planning-with-files/scripts/session-catchup.py
@@ -231,11 +231,12 @@ def main():
     messages = parse_session_messages(target_session)
     last_update_line, last_update_file = find_last_planning_update(messages)
 
-    # Only output if there's unsynced content
+    # No planning updates in the target session; skip catchup output.
     if last_update_line < 0:
-        messages_after = extract_messages_after(messages, len(messages) - 30)
-    else:
-        messages_after = extract_messages_after(messages, last_update_line)
+        return
+
+    # Only output if there's unsynced content
+    messages_after = extract_messages_after(messages, last_update_line)
 
     if not messages_after:
         return
@@ -244,11 +245,8 @@ def main():
     print("\n[planning-with-files] SESSION CATCHUP DETECTED")
     print(f"Previous session: {target_session.stem}")
 
-    if last_update_line >= 0:
-        print(f"Last planning update: {last_update_file} at message #{last_update_line}")
-        print(f"Unsynced messages: {len(messages_after)}")
-    else:
-        print("No planning file updates found in previous session")
+    print(f"Last planning update: {last_update_file} at message #{last_update_line}")
+    print(f"Unsynced messages: {len(messages_after)}")
 
     print("\n--- UNSYNCED CONTEXT ---")
     for msg in messages_after[-15:]:  # Last 15 messages

--- a/.pi/skills/planning-with-files/scripts/session-catchup.py
+++ b/.pi/skills/planning-with-files/scripts/session-catchup.py
@@ -146,6 +146,9 @@ def main():
     has_planning_files = any(
         Path(project_path, f).exists() for f in PLANNING_FILES
     )
+    if not has_planning_files:
+        # No planning files in this project; skip catchup to avoid noise.
+        return
 
     if not project_dir.exists():
         # No previous sessions, nothing to catch up on
@@ -168,11 +171,12 @@ def main():
     messages = parse_session_messages(target_session)
     last_update_line, last_update_file = find_last_planning_update(messages)
 
-    # Only output if there's unsynced content
+    # No planning updates in the target session; skip catchup output.
     if last_update_line < 0:
-        messages_after = extract_messages_after(messages, len(messages) - 30)
-    else:
-        messages_after = extract_messages_after(messages, last_update_line)
+        return
+
+    # Only output if there's unsynced content
+    messages_after = extract_messages_after(messages, last_update_line)
 
     if not messages_after:
         return
@@ -181,11 +185,8 @@ def main():
     print("\n[planning-with-files] SESSION CATCHUP DETECTED")
     print(f"Previous session: {target_session.stem}")
 
-    if last_update_line >= 0:
-        print(f"Last planning update: {last_update_file} at message #{last_update_line}")
-        print(f"Unsynced messages: {len(messages_after)}")
-    else:
-        print("No planning file updates found in previous session")
+    print(f"Last planning update: {last_update_file} at message #{last_update_line}")
+    print(f"Unsynced messages: {len(messages_after)}")
 
     print("\n--- UNSYNCED CONTEXT ---")
     for msg in messages_after[-15:]:  # Last 15 messages

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,6 +61,12 @@ These amazing people have contributed code, documentation, or significant improv
 
 ### Other Contributors
 
+- **[@gydx6](https://github.com/gydx6)** - [PR #79](https://github.com/OthmanAdi/planning-with-files/pull/79)
+  - Fixed session-catchup false positives in all 9 skill-distributed copies
+  - Added early return guards for non-planning projects
+  - Thorough bug report with root cause analysis
+  - **Impact:** Eliminates noise from false catchup reports
+
 - **[@tobrun](https://github.com/tobrun)** - [PR #3](https://github.com/OthmanAdi/planning-with-files/pull/3)
   - Early directory structure improvements
   - Helped identify optimal repository layout
@@ -112,6 +118,6 @@ If you've contributed and don't see your name here, please open an issue! We wan
 
 ---
 
-**Total Contributors:** 11+ and growing!
+**Total Contributors:** 12+ and growing!
 
-*Last updated: January 27, 2026*
+*Last updated: February 21, 2026*

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ If this skill helps you work smarter, that's all I wanted.
 <details>
 <summary><strong>📦 Releases & Session Recovery</strong></summary>
 
-### Current Version: v2.15.0
+### Current Version: v2.15.1
 
 | Version | Highlights |
 |---------|------------|
+| **v2.15.1** | Session catchup false-positive fix (thanks @gydx6!) |
 | **v2.15.0** | `/plan:status` command, OpenCode compatibility fix |
 | **v2.14.0** | Pi Agent support, OpenClaw docs update, Codex path fix |
 | **v2.11.0** | `/plan` command for easier autocomplete |
@@ -43,6 +44,8 @@ If this skill helps you work smarter, that's all I wanted.
 | **v2.2.0** | Session recovery, Windows PowerShell, OS-aware hooks |
 
 [View all releases](https://github.com/OthmanAdi/planning-with-files/releases) · [CHANGELOG](CHANGELOG.md)
+
+> 🧪 **Experimental:** Isolated parallel planning (`.planning/{uuid}/` folders) is being tested on [`experimental/isolated-planning`](https://github.com/OthmanAdi/planning-with-files/tree/experimental/isolated-planning). Try it and share feedback!
 
 ---
 
@@ -101,7 +104,7 @@ A Claude Code plugin that transforms your workflow to use persistent markdown fi
 [![Kiro](https://img.shields.io/badge/Kiro-Steering-00D4AA)](https://kiro.dev/docs/cli/steering/)
 [![AdaL CLI](https://img.shields.io/badge/AdaL%20CLI-Skills-9B59B6)](https://docs.sylph.ai/features/plugins-and-skills)
 [![Pi Agent](https://img.shields.io/badge/Pi%20Agent-Skills-FF4081)](https://pi.dev)
-[![Version](https://img.shields.io/badge/version-2.15.0-brightgreen)](https://github.com/OthmanAdi/planning-with-files/releases)
+[![Version](https://img.shields.io/badge/version-2.15.1-brightgreen)](https://github.com/OthmanAdi/planning-with-files/releases)
 [![SkillCheck Validated](https://img.shields.io/badge/SkillCheck-Validated-4c1)](https://getskillcheck.com)
 
 ## Quick Install


### PR DESCRIPTION
## Summary
This PR ports a set of parallel-safe planning extensions from our production usage into the upstream skill, while keeping the core Manus workflow intact.

## Original behavior (upstream)
- Planning files were created directly in project root (`task_plan.md`, `findings.md`, `progress.md`).
- Hooks read/write a single root-level `task_plan.md`.
- Session catchup did not scope to a specific active plan directory.

## Added extensions in this PR
- Introduce isolated per-task plan folders under `./.planning/{plan_id}`.
- Generate a UUID for every new plan session.
- Create and maintain `.planning/.active_plan` as shared default pointer.
- Add per-terminal parallel pinning via `PLAN_ID` environment variable.
- Add active plan resolver scripts for Unix + PowerShell:
  - `resolve-plan-dir.sh` / `resolve-plan-dir.ps1`
  - `set-active-plan.sh` / `set-active-plan.ps1`
- Update init/check scripts (root + skill) to operate on active plan directories.
- Update hooks in `skills/planning-with-files/SKILL.md` to resolve and read the active plan before actions.
- Update examples/reference to document isolated plan paths and parallel-safe usage.
- Update root `scripts/session-catchup.py` to scope planning updates to active `.planning/{plan_id}` when available.

## Why this helps
- Multiple plans can run in parallel without overwriting each other's planning files.
- Reduces cross-task context pollution in long-running or multi-terminal workflows.
- Keeps a safe default pointer (`.active_plan`) while enabling explicit session pinning (`PLAN_ID`).

## Verification
- Ran Python compile checks for catchup scripts.
- Validated root and skill init/check flows in temporary directories:
  - `init-session` creates `.planning/{uuid}` + 3 planning files.
  - `resolve-plan-dir` returns the expected active plan path.
  - `check-complete` reports status using the resolved active plan file.

## Scope
- This PR updates the canonical skill and its root script equivalents used by hooks.
- IDE-specific skill variants are intentionally left for follow-up to keep this change focused and reviewable.

---
Prepared collaboratively by **ciberponk** and **Codex (GPT-5)**.
