### PR TITLE
feat: improve skill metadata and description for better discoverability

### DIFF
--- a/skills/planning-with-files/SKILL.md
+++ b/skills/planning-with-files/SKILL.md
@@ -1,17 +1,8 @@
 ---
 name: planning-with-files
-version: "2.10.0"
-description: Implements Manus-style file-based planning for complex tasks. Creates task_plan.md, findings.md, and progress.md. Use when starting complex multi-step tasks, research projects, or any task requiring >5 tool calls. Now with automatic session recovery after /clear.
+description: Implements Manus-style file-based planning to organize and track progress on complex tasks. Creates task_plan.md, findings.md, and progress.md. Use when asked to plan out, break down, or organize a multi-step project, research task, or any work requiring >5 tool calls. Supports automatic session recovery after /clear.
 user-invocable: true
-allowed-tools:
-  - Read
-  - Write
-  - Edit
-  - Bash
-  - Glob
-  - Grep
-  - WebFetch
-  - WebSearch
+allowed-tools: "Read, Write, Edit, Bash, Glob, Grep, WebFetch, WebSearch"
 hooks:
   PreToolUse:
     - matcher: "Write|Edit|Bash|Read|Glob|Grep"
@@ -51,6 +42,8 @@ hooks:
             else
               sh "$SCRIPT_DIR/check-complete.sh"
             fi
+metadata:
+  version: "2.10.0"
 ---
 
 # Planning with Files


### PR DESCRIPTION
👋  hullo @OthmanAdi 

I ran your skills through a `tessl skill review` and found some ways to improve discoverability and usability. I hope this is welcome, and helpful.

Summary: 

| Area | Before | After |
|------|--------|-------|
| Description score | 0% (blocked) | 100% |
| Content score | 0% (blocked) | 100% |
| allowed-tools format | YAML list (invalid) | comma-separated string (valid) | | metadata.version | missing | added (2.10.0) |
| trigger terms | limited | added "plan out", "break down", "organize", "track progress" |

Details:

- Fixed `allowed-tools` from YAML list to string format (was causing validation failure)
- Moved `version` from top-level frontmatter to `metadata.version` (standard location)
- Enriched description with natural trigger terms for better skill matching
- No changes to skill behaviour, templates, scripts, or content

These were pretty straightforward changes to bring the skill in line with what performs well against Anthropic's best practices. Full disclosure, I work at @tesslio where we build tooling around this. Not a pitch, just fixes that were not time consuming to make, so I thought I'd offer them as a PR.

Of course, if you'd like to get all your skills to 100%, click [here](https://tessl.io/registry/skills/submit) to trigger the evals and iterate some more, otherwise I'm happy to offer more improvements as I find them.

Thanks in advance! Have a great day! 😸 