### PR TITLE
fix: check-complete.ps1 fails to parse on PowerShell

### DIFF
--- a/.adal/skills/planning-with-files/scripts/check-complete.ps1
+++ b/.adal/skills/planning-with-files/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/.codebuddy/skills/planning-with-files/scripts/check-complete.ps1
+++ b/.codebuddy/skills/planning-with-files/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/.codex/skills/planning-with-files/scripts/check-complete.ps1
+++ b/.codex/skills/planning-with-files/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/.continue/skills/planning-with-files/scripts/check-complete.ps1
+++ b/.continue/skills/planning-with-files/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/.gemini/skills/planning-with-files/scripts/check-complete.ps1
+++ b/.gemini/skills/planning-with-files/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/.kiro/scripts/check-complete.ps1
+++ b/.kiro/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/.mastracode/skills/planning-with-files/scripts/check-complete.ps1
+++ b/.mastracode/skills/planning-with-files/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/.openclaw/skills/planning-with-files/scripts/check-complete.ps1
+++ b/.openclaw/skills/planning-with-files/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/.opencode/skills/planning-with-files/scripts/check-complete.ps1
+++ b/.opencode/skills/planning-with-files/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/.pi/skills/planning-with-files/scripts/check-complete.ps1
+++ b/.pi/skills/planning-with-files/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/scripts/check-complete.ps1
+++ b/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0

--- a/skills/planning-with-files/scripts/check-complete.ps1
+++ b/skills/planning-with-files/scripts/check-complete.ps1
@@ -1,5 +1,5 @@
 # Check if all phases in task_plan.md are complete
-# Always exits 0 — uses stdout for status reporting
+# Always exits 0 -- uses stdout for status reporting
 # Used by Stop hook to report task completion status
 
 param(
@@ -7,7 +7,7 @@ param(
 )
 
 if (-not (Test-Path $PlanFile)) {
-    Write-Host "[planning-with-files] No task_plan.md found — no active planning session."
+    Write-Host '[planning-with-files] No task_plan.md found -- no active planning session.'
     exit 0
 }
 
@@ -29,16 +29,16 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
-# Report status (always exit 0 — incomplete task is a normal state)
+# Report status -- always exit 0, incomplete task is a normal state
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
-    Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
+    Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
 } else {
-    Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete)"
+    Write-Host ('[planning-with-files] Task in progress (' + $COMPLETE + '/' + $TOTAL + ' phases complete)')
     if ($IN_PROGRESS -gt 0) {
-        Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."
+        Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
     }
     if ($PENDING -gt 0) {
-        Write-Host "[planning-with-files] $PENDING phase(s) pending."
+        Write-Host ('[planning-with-files] ' + $PENDING + ' phase(s) pending.')
     }
 }
 exit 0


### PR DESCRIPTION
## Summary

- `check-complete.ps1` is completely non-functional on PowerShell due to special characters inside double-quoted strings
- Three categories of parse errors: UTF-8 em-dash in comments, `[` interpreted as array index, `()` interpreted as subexpressions
- Replaced double-quoted `Write-Host` strings with single-quoted strings + concatenation, and em-dashes with ASCII `--`
- Applied to all 12 tool variant copies (adal, codebuddy, codex, continue, gemini, kiro, mastracode, openclaw, opencode, pi, scripts, skills)

## Errors before fix

```
At check-complete.ps1:9 char:33
+ if (-not (Test-Path $PlanFile)) {
+                                 ~
Missing closing '}' in statement block or type definition.
At check-complete.ps1:32 char:69
+ # Report status (always exit 0 — incomplete task is a normal state)
+                                                                     ~
Unexpected token ')' in expression or statement.
    + FullyQualifiedErrorId : MissingEndCurlyBrace
```

```
At check-complete.ps1:36 char:18
+     Write-Host "[planning-with-files] Task in progress ($COMPLETE/$TO ...
+                  ~
Array index expression is missing or not valid.
    + FullyQualifiedErrorId : MissingArrayIndexExpression
```

## Root cause

| Character | PowerShell interpretation | Location |
|-----------|--------------------------|----------|
| `—` (U+2014 em-dash) | Breaks parser mid-comment | Line 3, 10, 32 |
| `[planning-with-files]` | Array index expression | Lines 10, 34, 36, 38, 41 |
| `($COMPLETE/$TOTAL ...)` | Subexpression | Lines 34, 36 |
| `phase(s)` | Subexpression | Lines 38, 41 |

## Fix

```powershell
# Before (broken)
Write-Host "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL)"
Write-Host "[planning-with-files] $IN_PROGRESS phase(s) still in progress."

# After (working)
Write-Host ('[planning-with-files] ALL PHASES COMPLETE (' + $COMPLETE + '/' + $TOTAL + ')')
Write-Host ('[planning-with-files] ' + $IN_PROGRESS + ' phase(s) still in progress.')
```

## Test plan

Verified on Windows 11 with PowerShell 5.1:

- [x] In-progress plan: correct phase counts and status lines
- [x] All-complete plan: `ALL PHASES COMPLETE (3/3)`
- [x] No plan file: graceful message, exit 0
- [x] Inline `[complete]` format: fallback regex works
- [x] `init-session.ps1` checked — no issues found

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)