### PR TITLE
fix(codex): correct broken Advanced Topics links in planning-with-files SKILL

### DIFF
--- a/.codex/skills/planning-with-files/SKILL.md
+++ b/.codex/skills/planning-with-files/SKILL.md
@@ -201,8 +201,8 @@ Helper scripts for automation:
 
 ## Advanced Topics
 
-- **Manus Principles:** See [reference.md](reference.md)
-- **Real Examples:** See [examples.md](examples.md)
+- **Manus Principles:** See [references/reference.md](references/reference.md)
+- **Real Examples:** See [references/examples.md](references/examples.md)
 
 ## Anti-Patterns
 


### PR DESCRIPTION
## What
Fix 2 broken links in:
- `.codex/skills/planning-with-files/SKILL.md`

Updated:
- [reference.md](reference.md) -> [references/reference.md](references/reference.md)
- [examples.md](examples.md) -> [references/examples.md](references/examples.md)

## Why
The linked files live under `references/` in this repository, so current links are broken for Codex users.

## Scope
- 1 file changed
- 2 links corrected
- No behavior changes

Closes #91