### PR TITLE
Fix docs path issues, examples naming, and sync CLI help behavior

### DIFF
--- a/.adal/skills/planning-with-files/references/examples.md
+++ b/.adal/skills/planning-with-files/references/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.agent/skills/planning-with-files/examples.md
+++ b/.agent/skills/planning-with-files/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.codebuddy/skills/planning-with-files/references/examples.md
+++ b/.codebuddy/skills/planning-with-files/references/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.codex/skills/planning-with-files/references/examples.md
+++ b/.codex/skills/planning-with-files/references/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.continue/skills/planning-with-files/examples.md
+++ b/.continue/skills/planning-with-files/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.cursor/skills/planning-with-files/examples.md
+++ b/.cursor/skills/planning-with-files/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.factory/skills/planning-with-files/examples.md
+++ b/.factory/skills/planning-with-files/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.gemini/skills/planning-with-files/references/examples.md
+++ b/.gemini/skills/planning-with-files/references/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.kilocode/skills/planning-with-files/examples.md
+++ b/.kilocode/skills/planning-with-files/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.mastracode/skills/planning-with-files/references/examples.md
+++ b/.mastracode/skills/planning-with-files/references/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.openclaw/skills/planning-with-files/references/examples.md
+++ b/.openclaw/skills/planning-with-files/references/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.opencode/skills/planning-with-files/examples.md
+++ b/.opencode/skills/planning-with-files/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/.pi/skills/planning-with-files/examples.md
+++ b/.pi/skills/planning-with-files/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ When your context fills up and you run `/clear`, this skill **automatically reco
 | Cursor | ✅ Full Support | [Cursor Setup](docs/cursor.md) | Skills + Hooks |
 | Continue | ✅ Full Support | [Continue Setup](docs/continue.md) | Skills + Prompt files |
 | Kilocode | ✅ Full Support | [Kilocode Setup](docs/kilocode.md) | Skills |
-| OpenCode | ✅ Full Support | [OpenCode Setup](docs/opencode.md) | Personal/Project Skill |
+| OpenCode | ⚠️ Partial Support | [OpenCode Setup](docs/opencode.md) | Personal/Project Skill (session catchup limited) |
 | Codex | ✅ Full Support | [Codex Setup](docs/codex.md) | Personal Skill |
 | FactoryAI Droid | ✅ Full Support | [Factory Setup](docs/factory.md) | Workspace/Personal Skill |
 | Antigravity | ✅ Full Support | [Antigravity Setup](docs/antigravity.md) | Workspace/Personal Skill |

--- a/docs/factory.md
+++ b/docs/factory.md
@@ -248,5 +248,5 @@ Factory Droid will reference them automatically.
 
 - [Quick Start Guide](quickstart.md)
 - [Workflow Diagram](workflow.md)
-- [Manus Principles](../skills/planning-with-files/references.md)
-- [Real Examples](../skills/planning-with-files/examples.md)
+- [Manus Principles](../.factory/skills/planning-with-files/references.md)
+- [Real Examples](../.factory/skills/planning-with-files/examples.md)

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -6,7 +6,7 @@ planning-with-files works with OpenCode as a personal or project skill.
 
 ## Installation
 
-See [.opencode/INSTALL.md](../.opencode/INSTALL.md) for detailed installation instructions.
+See [docs/installation.md](installation.md) for detailed installation instructions.
 
 ### Quick Install (Global)
 

--- a/scripts/sync-ide-folders.py
+++ b/scripts/sync-ide-folders.py
@@ -19,7 +19,7 @@ Use --dry-run to preview changes without writing anything.
 Use --verify  to check for drift without making changes (exits 1 if drift found).
 """
 
-import os
+import argparse
 import shutil
 import sys
 import hashlib
@@ -226,9 +226,31 @@ def sync_file(src, dst, *, dry_run=False):
 
 # ─── Main ──────────────────────────────────────────────────────────
 
-def main():
-    dry_run = "--dry-run" in sys.argv
-    verify = "--verify" in sys.argv
+def parse_args(argv=None):
+    """Parse CLI arguments for sync behavior."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Sync shared planning-with-files assets from canonical source "
+            "to IDE-specific folders."
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without writing files.",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Check for drift only; exit with code 1 if drift is found.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    dry_run = args.dry_run
+    verify = args.verify
 
     # Must run from repo root
     if not CANONICAL.exists():

--- a/skills/planning-with-files/examples.md
+++ b/skills/planning-with-files/examples.md
@@ -34,14 +34,14 @@ Create a research summary on the benefits of morning exercise.
 ```bash
 Read task_plan.md           # Refresh goals
 WebSearch "morning exercise benefits"
-Write notes.md              # Store findings
+Write findings.md              # Store findings
 Edit task_plan.md           # Mark Phase 2 complete
 ```
 
 ### Loop 3: Synthesize
 ```bash
 Read task_plan.md           # Refresh goals
-Read notes.md               # Get findings
+Read findings.md               # Get findings
 Write morning_exercise_summary.md
 Edit task_plan.md           # Mark Phase 3 complete
 ```
@@ -120,9 +120,9 @@ Add functional dark mode toggle to settings.
 **Currently in Phase 3** - Building toggle component
 ```
 
-**notes.md:**
+**findings.md:**
 ```markdown
-# Notes: Dark Mode Implementation
+# Findings: Dark Mode Implementation
 
 ## Existing Theme System
 - Located in: src/styles/theme.ts


### PR DESCRIPTION
## Summary
This PR fixes four tracked issues around docs consistency and tooling behavior:

1. Fix broken OpenCode installation link in `docs/opencode.md`.
2. Fix broken Factory "See Also" links in `docs/factory.md`.
3. Replace stale `notes.md` references with `findings.md` in examples across canonical and mirrored IDE docs.
4. Update OpenCode support status in README to match actual behavior.
5. Fix `scripts/sync-ide-folders.py` so `-h/--help` prints usage and exits cleanly (without running sync).

## Validation
- `python3 scripts/sync-ide-folders.py --help`
- `python3 scripts/sync-ide-folders.py --dry-run`

## Notes
`--verify` currently reports one pre-existing drift in `.codebuddy/skills/planning-with-files/scripts/session-catchup.py`; this PR does not change that file.

Closes #95
Closes #96
Closes #97
Closes #98
