### PR TITLE
feat: add openclaw-github-repo-commander to Community Built

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If this skill helps you work smarter, that's all I wanted.
 | [multi-manus-planning](https://github.com/kmichels/multi-manus-planning) | [@kmichels](https://github.com/kmichels) | Multi-project support, SessionStart git sync |
 | [plan-cascade](https://github.com/Taoidle/plan-cascade) | [@Taoidle](https://github.com/Taoidle) | Multi-level task orchestration, parallel execution, multi-agent collaboration |
 | [agentfund-skill](https://github.com/RioTheGreat-ai/agentfund-skill) | [@RioTheGreat-ai](https://github.com/RioTheGreat-ai) | Crowdfunding for AI agents with milestone-based escrow on Base |
+| [openclaw-github-repo-commander](https://github.com/wd041216-bit/openclaw-github-repo-commander) | [@wd041216-bit](https://github.com/wd041216-bit) | 7-stage super workflow for GitHub repo management, audit, PR review, competitor analysis, and automated cleanup |
 
 *Built something? [Open an issue](https://github.com/OthmanAdi/planning-with-files/issues) to get listed!*
 


### PR DESCRIPTION
## Summary

Adds [openclaw-github-repo-commander](https://github.com/wd041216-bit/openclaw-github-repo-commander) to the **Community Built** section.

## What is this skill?

A 7-stage super workflow skill for GitHub repository management, built specifically for OpenClaw. It automates:

- **Stage 1 Intake** — Repo structure analysis and success criteria definition
- **Stage 2 Execution** — Automated audit via `scripts/repo-audit.sh` (7 checks)
- **Stage 3 Reflection** — Deep content quality, security, and consistency review
- **Stage 4 Competitor Analysis** — Benchmarking against top repos via `scripts/competitor-search.sh`
- **Stage 5 Synthesis** — Optimization plan generation
- **Stage 6 Iteration** — Automated cleanup (duplicates, secrets, dead code, docs)
- **Stage 7 Validation** — Final verification and GitHub push

## Why it belongs here

This skill was built *using* `planning-with-files` as its foundational workflow pattern — the 3-file planning system is embedded in its Stage 1 Intake phase. It's a direct extension of the Manus-style planning philosophy into GitHub repo management.

## AI Disclosure

This PR was written with AI assistance (OpenClaw/Manus). The skill itself was developed and tested over multiple super-workflow iterations.