### PR TITLE
feat: add Chinese localization / 添加中文支持

### DIFF
--- a/skills/planning-with-files/SKILL.md
+++ b/skills/planning-with-files/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planning-with-files
-description: Implements Manus-style file-based planning to organize and track progress on complex tasks. Creates task_plan.md, findings.md, and progress.md. Use when asked to plan out, break down, or organize a multi-step project, research task, or any work requiring >5 tool calls. Supports automatic session recovery after /clear.
+description: Implements Manus-style file-based planning to organize and track progress on complex tasks. Creates task_plan.md, findings.md, and progress.md. Use when asked to plan out, break down, or organize a multi-step project, research task, or any work requiring >5 tool calls. Supports automatic session recovery after /clear. 中文触发词：任务规划、项目计划、制定计划、分解任务、多步骤规划、进度跟踪、文件规划、帮我规划、拆解项目
 user-invocable: true
 allowed-tools: "Read, Write, Edit, Bash, Glob, Grep"
 hooks:


### PR DESCRIPTION
## Summary
Add Chinese language support to make this skill more accessible to Chinese-speaking users.

添加中文支持，让中文用户更容易发现和使用此技能。

## Changes
- Added Chinese trigger words (中文触发词) to the `description` field in SKILL.md frontmatter
- Keywords added: 任务规划、项目计划、制定计划、分解任务、多步骤规划、进度跟踪、文件规划、帮我规划、拆解项目

## Why
Chinese is one of the most widely spoken languages among developers. Adding Chinese trigger words helps Chinese-speaking users discover and invoke this skill naturally in their own language, without changing any existing English functionality.

This is a non-breaking, additive change that only extends the existing description content.