### PR TITLE
fix: restore Codex session-catchup fallback

### DIFF
--- a/.adal/skills/planning-with-files/scripts/session-catchup.py
+++ b/.adal/skills/planning-with-files/scripts/session-catchup.py
@@ -13,18 +13,31 @@ import sys
 import os
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
-from datetime import datetime
 
 PLANNING_FILES = ['task_plan.md', 'progress.md', 'findings.md']
 
 
-def get_project_dir(project_path: str) -> Path:
-    """Convert project path to Claude's storage path format."""
+def get_project_dir(project_path: str) -> Tuple[Optional[Path], Optional[str]]:
+    """Resolve session storage path for the current runtime variant."""
     sanitized = project_path.replace('/', '-')
     if not sanitized.startswith('-'):
         sanitized = '-' + sanitized
     sanitized = sanitized.replace('_', '-')
-    return Path.home() / '.claude' / 'projects' / sanitized
+
+    claude_path = Path.home() / '.claude' / 'projects' / sanitized
+
+    # Codex stores sessions in ~/.codex/sessions with a different format.
+    # Avoid silently scanning Claude paths when running from Codex skill folder.
+    script_path = Path(__file__).as_posix().lower()
+    is_codex_variant = '/.codex/' in script_path
+    codex_sessions_dir = Path.home() / '.codex' / 'sessions'
+    if is_codex_variant and codex_sessions_dir.exists() and not claude_path.exists():
+        return None, (
+            "[planning-with-files] Session catchup skipped: Codex stores sessions "
+            "in ~/.codex/sessions and native Codex parsing is not implemented yet."
+        )
+
+    return claude_path, None
 
 
 def get_sessions_sorted(project_dir: Path) -> List[Path]:
@@ -140,7 +153,6 @@ def extract_messages_after(messages: List[Dict], after_line: int) -> List[Dict]:
 
 def main():
     project_path = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
-    project_dir = get_project_dir(project_path)
 
     # Check if planning files exist (indicates active task)
     has_planning_files = any(
@@ -148,6 +160,11 @@ def main():
     )
     if not has_planning_files:
         # No planning files in this project; skip catchup to avoid noise.
+        return
+
+    project_dir, skip_reason = get_project_dir(project_path)
+    if skip_reason:
+        print(skip_reason)
         return
 
     if not project_dir.exists():

--- a/.codebuddy/skills/planning-with-files/scripts/session-catchup.py
+++ b/.codebuddy/skills/planning-with-files/scripts/session-catchup.py
@@ -13,18 +13,31 @@ import sys
 import os
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
-from datetime import datetime
 
 PLANNING_FILES = ['task_plan.md', 'progress.md', 'findings.md']
 
 
-def get_project_dir(project_path: str) -> Path:
-    """Convert project path to Claude's storage path format."""
+def get_project_dir(project_path: str) -> Tuple[Optional[Path], Optional[str]]:
+    """Resolve session storage path for the current runtime variant."""
     sanitized = project_path.replace('/', '-')
     if not sanitized.startswith('-'):
         sanitized = '-' + sanitized
     sanitized = sanitized.replace('_', '-')
-    return Path.home() / '.claude' / 'projects' / sanitized
+
+    claude_path = Path.home() / '.claude' / 'projects' / sanitized
+
+    # Codex stores sessions in ~/.codex/sessions with a different format.
+    # Avoid silently scanning Claude paths when running from Codex skill folder.
+    script_path = Path(__file__).as_posix().lower()
+    is_codex_variant = '/.codex/' in script_path
+    codex_sessions_dir = Path.home() / '.codex' / 'sessions'
+    if is_codex_variant and codex_sessions_dir.exists() and not claude_path.exists():
+        return None, (
+            "[planning-with-files] Session catchup skipped: Codex stores sessions "
+            "in ~/.codex/sessions and native Codex parsing is not implemented yet."
+        )
+
+    return claude_path, None
 
 
 def get_sessions_sorted(project_dir: Path) -> List[Path]:
@@ -140,7 +153,6 @@ def extract_messages_after(messages: List[Dict], after_line: int) -> List[Dict]:
 
 def main():
     project_path = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
-    project_dir = get_project_dir(project_path)
 
     # Check if planning files exist (indicates active task)
     has_planning_files = any(
@@ -148,6 +160,11 @@ def main():
     )
     if not has_planning_files:
         # No planning files in this project; skip catchup to avoid noise.
+        return
+
+    project_dir, skip_reason = get_project_dir(project_path)
+    if skip_reason:
+        print(skip_reason)
         return
 
     if not project_dir.exists():

--- a/.codex/skills/planning-with-files/scripts/session-catchup.py
+++ b/.codex/skills/planning-with-files/scripts/session-catchup.py
@@ -13,18 +13,31 @@ import sys
 import os
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
-from datetime import datetime
 
 PLANNING_FILES = ['task_plan.md', 'progress.md', 'findings.md']
 
 
-def get_project_dir(project_path: str) -> Path:
-    """Convert project path to Claude's storage path format."""
+def get_project_dir(project_path: str) -> Tuple[Optional[Path], Optional[str]]:
+    """Resolve session storage path for the current runtime variant."""
     sanitized = project_path.replace('/', '-')
     if not sanitized.startswith('-'):
         sanitized = '-' + sanitized
     sanitized = sanitized.replace('_', '-')
-    return Path.home() / '.claude' / 'projects' / sanitized
+
+    claude_path = Path.home() / '.claude' / 'projects' / sanitized
+
+    # Codex stores sessions in ~/.codex/sessions with a different format.
+    # Avoid silently scanning Claude paths when running from Codex skill folder.
+    script_path = Path(__file__).as_posix().lower()
+    is_codex_variant = '/.codex/' in script_path
+    codex_sessions_dir = Path.home() / '.codex' / 'sessions'
+    if is_codex_variant and codex_sessions_dir.exists() and not claude_path.exists():
+        return None, (
+            "[planning-with-files] Session catchup skipped: Codex stores sessions "
+            "in ~/.codex/sessions and native Codex parsing is not implemented yet."
+        )
+
+    return claude_path, None
 
 
 def get_sessions_sorted(project_dir: Path) -> List[Path]:
@@ -140,7 +153,6 @@ def extract_messages_after(messages: List[Dict], after_line: int) -> List[Dict]:
 
 def main():
     project_path = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
-    project_dir = get_project_dir(project_path)
 
     # Check if planning files exist (indicates active task)
     has_planning_files = any(
@@ -148,6 +160,11 @@ def main():
     )
     if not has_planning_files:
         # No planning files in this project; skip catchup to avoid noise.
+        return
+
+    project_dir, skip_reason = get_project_dir(project_path)
+    if skip_reason:
+        print(skip_reason)
         return
 
     if not project_dir.exists():

--- a/.continue/skills/planning-with-files/scripts/session-catchup.py
+++ b/.continue/skills/planning-with-files/scripts/session-catchup.py
@@ -13,18 +13,31 @@ import sys
 import os
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
-from datetime import datetime
 
 PLANNING_FILES = ['task_plan.md', 'progress.md', 'findings.md']
 
 
-def get_project_dir(project_path: str) -> Path:
-    """Convert project path to Claude's storage path format."""
+def get_project_dir(project_path: str) -> Tuple[Optional[Path], Optional[str]]:
+    """Resolve session storage path for the current runtime variant."""
     sanitized = project_path.replace('/', '-')
     if not sanitized.startswith('-'):
         sanitized = '-' + sanitized
     sanitized = sanitized.replace('_', '-')
-    return Path.home() / '.claude' / 'projects' / sanitized
+
+    claude_path = Path.home() / '.claude' / 'projects' / sanitized
+
+    # Codex stores sessions in ~/.codex/sessions with a different format.
+    # Avoid silently scanning Claude paths when running from Codex skill folder.
+    script_path = Path(__file__).as_posix().lower()
+    is_codex_variant = '/.codex/' in script_path
+    codex_sessions_dir = Path.home() / '.codex' / 'sessions'
+    if is_codex_variant and codex_sessions_dir.exists() and not claude_path.exists():
+        return None, (
+            "[planning-with-files] Session catchup skipped: Codex stores sessions "
+            "in ~/.codex/sessions and native Codex parsing is not implemented yet."
+        )
+
+    return claude_path, None
 
 
 def get_sessions_sorted(project_dir: Path) -> List[Path]:
@@ -140,7 +153,6 @@ def extract_messages_after(messages: List[Dict], after_line: int) -> List[Dict]:
 
 def main():
     project_path = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
-    project_dir = get_project_dir(project_path)
 
     # Check if planning files exist (indicates active task)
     has_planning_files = any(
@@ -148,6 +160,11 @@ def main():
     )
     if not has_planning_files:
         # No planning files in this project; skip catchup to avoid noise.
+        return
+
+    project_dir, skip_reason = get_project_dir(project_path)
+    if skip_reason:
+        print(skip_reason)
         return
 
     if not project_dir.exists():

--- a/.gemini/skills/planning-with-files/scripts/session-catchup.py
+++ b/.gemini/skills/planning-with-files/scripts/session-catchup.py
@@ -13,18 +13,31 @@ import sys
 import os
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
-from datetime import datetime
 
 PLANNING_FILES = ['task_plan.md', 'progress.md', 'findings.md']
 
 
-def get_project_dir(project_path: str) -> Path:
-    """Convert project path to Claude's storage path format."""
+def get_project_dir(project_path: str) -> Tuple[Optional[Path], Optional[str]]:
+    """Resolve session storage path for the current runtime variant."""
     sanitized = project_path.replace('/', '-')
     if not sanitized.startswith('-'):
         sanitized = '-' + sanitized
     sanitized = sanitized.replace('_', '-')
-    return Path.home() / '.claude' / 'projects' / sanitized
+
+    claude_path = Path.home() / '.claude' / 'projects' / sanitized
+
+    # Codex stores sessions in ~/.codex/sessions with a different format.
+    # Avoid silently scanning Claude paths when running from Codex skill folder.
+    script_path = Path(__file__).as_posix().lower()
+    is_codex_variant = '/.codex/' in script_path
+    codex_sessions_dir = Path.home() / '.codex' / 'sessions'
+    if is_codex_variant and codex_sessions_dir.exists() and not claude_path.exists():
+        return None, (
+            "[planning-with-files] Session catchup skipped: Codex stores sessions "
+            "in ~/.codex/sessions and native Codex parsing is not implemented yet."
+        )
+
+    return claude_path, None
 
 
 def get_sessions_sorted(project_dir: Path) -> List[Path]:
@@ -140,7 +153,6 @@ def extract_messages_after(messages: List[Dict], after_line: int) -> List[Dict]:
 
 def main():
     project_path = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
-    project_dir = get_project_dir(project_path)
 
     # Check if planning files exist (indicates active task)
     has_planning_files = any(
@@ -148,6 +160,11 @@ def main():
     )
     if not has_planning_files:
         # No planning files in this project; skip catchup to avoid noise.
+        return
+
+    project_dir, skip_reason = get_project_dir(project_path)
+    if skip_reason:
+        print(skip_reason)
         return
 
     if not project_dir.exists():

--- a/.openclaw/skills/planning-with-files/scripts/session-catchup.py
+++ b/.openclaw/skills/planning-with-files/scripts/session-catchup.py
@@ -13,18 +13,31 @@ import sys
 import os
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
-from datetime import datetime
 
 PLANNING_FILES = ['task_plan.md', 'progress.md', 'findings.md']
 
 
-def get_project_dir(project_path: str) -> Path:
-    """Convert project path to Claude's storage path format."""
+def get_project_dir(project_path: str) -> Tuple[Optional[Path], Optional[str]]:
+    """Resolve session storage path for the current runtime variant."""
     sanitized = project_path.replace('/', '-')
     if not sanitized.startswith('-'):
         sanitized = '-' + sanitized
     sanitized = sanitized.replace('_', '-')
-    return Path.home() / '.claude' / 'projects' / sanitized
+
+    claude_path = Path.home() / '.claude' / 'projects' / sanitized
+
+    # Codex stores sessions in ~/.codex/sessions with a different format.
+    # Avoid silently scanning Claude paths when running from Codex skill folder.
+    script_path = Path(__file__).as_posix().lower()
+    is_codex_variant = '/.codex/' in script_path
+    codex_sessions_dir = Path.home() / '.codex' / 'sessions'
+    if is_codex_variant and codex_sessions_dir.exists() and not claude_path.exists():
+        return None, (
+            "[planning-with-files] Session catchup skipped: Codex stores sessions "
+            "in ~/.codex/sessions and native Codex parsing is not implemented yet."
+        )
+
+    return claude_path, None
 
 
 def get_sessions_sorted(project_dir: Path) -> List[Path]:
@@ -140,7 +153,6 @@ def extract_messages_after(messages: List[Dict], after_line: int) -> List[Dict]:
 
 def main():
     project_path = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
-    project_dir = get_project_dir(project_path)
 
     # Check if planning files exist (indicates active task)
     has_planning_files = any(
@@ -148,6 +160,11 @@ def main():
     )
     if not has_planning_files:
         # No planning files in this project; skip catchup to avoid noise.
+        return
+
+    project_dir, skip_reason = get_project_dir(project_path)
+    if skip_reason:
+        print(skip_reason)
         return
 
     if not project_dir.exists():

--- a/.pi/skills/planning-with-files/scripts/session-catchup.py
+++ b/.pi/skills/planning-with-files/scripts/session-catchup.py
@@ -13,18 +13,31 @@ import sys
 import os
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
-from datetime import datetime
 
 PLANNING_FILES = ['task_plan.md', 'progress.md', 'findings.md']
 
 
-def get_project_dir(project_path: str) -> Path:
-    """Convert project path to Claude's storage path format."""
+def get_project_dir(project_path: str) -> Tuple[Optional[Path], Optional[str]]:
+    """Resolve session storage path for the current runtime variant."""
     sanitized = project_path.replace('/', '-')
     if not sanitized.startswith('-'):
         sanitized = '-' + sanitized
     sanitized = sanitized.replace('_', '-')
-    return Path.home() / '.claude' / 'projects' / sanitized
+
+    claude_path = Path.home() / '.claude' / 'projects' / sanitized
+
+    # Codex stores sessions in ~/.codex/sessions with a different format.
+    # Avoid silently scanning Claude paths when running from Codex skill folder.
+    script_path = Path(__file__).as_posix().lower()
+    is_codex_variant = '/.codex/' in script_path
+    codex_sessions_dir = Path.home() / '.codex' / 'sessions'
+    if is_codex_variant and codex_sessions_dir.exists() and not claude_path.exists():
+        return None, (
+            "[planning-with-files] Session catchup skipped: Codex stores sessions "
+            "in ~/.codex/sessions and native Codex parsing is not implemented yet."
+        )
+
+    return claude_path, None
 
 
 def get_sessions_sorted(project_dir: Path) -> List[Path]:
@@ -140,7 +153,6 @@ def extract_messages_after(messages: List[Dict], after_line: int) -> List[Dict]:
 
 def main():
     project_path = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
-    project_dir = get_project_dir(project_path)
 
     # Check if planning files exist (indicates active task)
     has_planning_files = any(
@@ -148,6 +160,11 @@ def main():
     )
     if not has_planning_files:
         # No planning files in this project; skip catchup to avoid noise.
+        return
+
+    project_dir, skip_reason = get_project_dir(project_path)
+    if skip_reason:
+        print(skip_reason)
         return
 
     if not project_dir.exists():

--- a/skills/planning-with-files/scripts/session-catchup.py
+++ b/skills/planning-with-files/scripts/session-catchup.py
@@ -13,18 +13,31 @@ import sys
 import os
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
-from datetime import datetime
 
 PLANNING_FILES = ['task_plan.md', 'progress.md', 'findings.md']
 
 
-def get_project_dir(project_path: str) -> Path:
-    """Convert project path to Claude's storage path format."""
+def get_project_dir(project_path: str) -> Tuple[Optional[Path], Optional[str]]:
+    """Resolve session storage path for the current runtime variant."""
     sanitized = project_path.replace('/', '-')
     if not sanitized.startswith('-'):
         sanitized = '-' + sanitized
     sanitized = sanitized.replace('_', '-')
-    return Path.home() / '.claude' / 'projects' / sanitized
+
+    claude_path = Path.home() / '.claude' / 'projects' / sanitized
+
+    # Codex stores sessions in ~/.codex/sessions with a different format.
+    # Avoid silently scanning Claude paths when running from Codex skill folder.
+    script_path = Path(__file__).as_posix().lower()
+    is_codex_variant = '/.codex/' in script_path
+    codex_sessions_dir = Path.home() / '.codex' / 'sessions'
+    if is_codex_variant and codex_sessions_dir.exists() and not claude_path.exists():
+        return None, (
+            "[planning-with-files] Session catchup skipped: Codex stores sessions "
+            "in ~/.codex/sessions and native Codex parsing is not implemented yet."
+        )
+
+    return claude_path, None
 
 
 def get_sessions_sorted(project_dir: Path) -> List[Path]:
@@ -140,7 +153,6 @@ def extract_messages_after(messages: List[Dict], after_line: int) -> List[Dict]:
 
 def main():
     project_path = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
-    project_dir = get_project_dir(project_path)
 
     # Check if planning files exist (indicates active task)
     has_planning_files = any(
@@ -148,6 +160,11 @@ def main():
     )
     if not has_planning_files:
         # No planning files in this project; skip catchup to avoid noise.
+        return
+
+    project_dir, skip_reason = get_project_dir(project_path)
+    if skip_reason:
+        print(skip_reason)
         return
 
     if not project_dir.exists():

--- a/tests/test_session_catchup.py
+++ b/tests/test_session_catchup.py
@@ -1,0 +1,64 @@
+import importlib.util
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_SOURCE = (
+    Path(__file__).resolve().parents[1]
+    / "skills/planning-with-files/scripts/session-catchup.py"
+)
+
+
+def load_module(script_path: Path):
+    spec = importlib.util.spec_from_file_location(
+        f"session_catchup_{script_path.stat().st_mtime_ns}",
+        script_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class SessionCatchupCodexTests(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.project_path = "/tmp/project"
+        self.codex_script = (
+            self.root / ".codex/skills/planning-with-files/scripts/session-catchup.py"
+        )
+        self.codex_script.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(SCRIPT_SOURCE, self.codex_script)
+        self.module = load_module(self.codex_script)
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_codex_variant_skips_when_only_codex_sessions_exist(self):
+        (self.root / ".codex/sessions").mkdir(parents=True, exist_ok=True)
+
+        with mock.patch("pathlib.Path.home", return_value=self.root):
+            project_dir, skip_reason = self.module.get_project_dir(self.project_path)
+
+        self.assertIsNone(project_dir)
+        self.assertIn("~/.codex/sessions", skip_reason)
+        self.assertIn("not implemented yet", skip_reason)
+
+    def test_codex_variant_uses_claude_path_when_project_exists(self):
+        (self.root / ".codex/sessions").mkdir(parents=True, exist_ok=True)
+        expected = self.root / ".claude/projects/-tmp-project"
+        expected.mkdir(parents=True, exist_ok=True)
+
+        with mock.patch("pathlib.Path.home", return_value=self.root):
+            project_dir, skip_reason = self.module.get_project_dir(self.project_path)
+
+        self.assertEqual(expected, project_dir)
+        self.assertIsNone(skip_reason)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
  ## Summary

  This restores the Codex-specific `session-catchup.py` fallback that was previously added in PR #100, but appears to have been overwritten by a later sync/update.

  ## Problem

  PR #100 added a Codex safeguard so the Codex variant would not silently scan Claude session storage (`~/.claude/projects`) when running from the Codex skill path.

  However, in the current codebase, the Codex-distributed `session-catchup.py` no longer contains that fallback logic. As a result, the Codex variant can again fall back to Claude-path
  behavior instead of explicitly skipping with a clear message.

  ## Root Cause

  From tracing the history locally:

  - PR #100 merged the Codex-specific fallback into the distributed Codex script
  - Later updates (including the v2.23.0 session-catchup changes) replaced the skill-distributed script contents from the shared source
  - The shared canonical skill script did not include the Codex fallback, so the earlier fix was effectively overwritten

  In other words, the previous fix was applied to a distributed copy, but not preserved in the canonical shared script that later syncs were based on.

  ## What this PR changes

  - Restores the Codex fallback behavior in the canonical skill-distributed `session-catchup.py`
  - Syncs the updated script back to the generated IDE copies, including `.codex/.../session-catchup.py`
  - Adds a regression test to prevent this behavior from being lost again

  ## Expected behavior

  When the script is running from a Codex skill path and `~/.codex/sessions` exists, but the equivalent Claude project session path does not exist, it should:

  - skip catchup explicitly
  - print a clear fallback message

  instead of silently scanning Claude session storage

  ## Verification

  I added and ran a regression test covering the Codex fallback behavior:

  ```bash
  python -m unittest discover -s tests -v

  And verified the generated IDE folders are back in sync:

  python scripts/sync-ide-folders.py --verify

  ## Why this approach

  This PR fixes the problem in the shared source (skills/planning-with-files/scripts/session-catchup.py) rather than patching only the Codex copy again, so future syncs do not overwrite the
  fix a second time.