### PR TITLE
feat: publish stack handshake contract and planning state adapter

### DIFF
--- a/contracts/stack-handshake.json
+++ b/contracts/stack-handshake.json
@@ -1,0 +1,15 @@
+{
+  "contractVersion": "1.0.0",
+  "component": "planning-with-files",
+  "interface": {
+    "health": "bash scripts/check-continue.sh",
+    "capabilities": [
+      "task_plan.md management",
+      "findings.md management",
+      "progress.md management",
+      "session-catchup"
+    ],
+    "export_state": "python scripts/stack_contract.py export --output <file>",
+    "import_state": "python scripts/stack_contract.py import --input <file>"
+  }
+}

--- a/scripts/stack_contract.py
+++ b/scripts/stack_contract.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+
+FILES = ["task_plan.md", "findings.md", "progress.md"]
+
+
+def export_state(output: Path):
+    root = Path.cwd()
+    payload = {
+        "component": "planning-with-files",
+        "exported_at": datetime.now().isoformat(),
+        "files": {},
+    }
+    for name in FILES:
+        p = root / name
+        payload["files"][name] = p.read_text(encoding="utf-8") if p.exists() else None
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def import_state(input_path: Path):
+    root = Path.cwd()
+    payload = json.loads(input_path.read_text(encoding="utf-8"))
+    for name, content in payload.get("files", {}).items():
+        if name in FILES and content is not None:
+            (root / name).write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="planning-with-files stack contract helper")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    ex = sub.add_parser("export")
+    ex.add_argument("--output", required=True)
+    im = sub.add_parser("import")
+    im.add_argument("--input", required=True)
+    args = parser.parse_args()
+    if args.cmd == "export":
+        export_state(Path(args.output))
+    else:
+        import_state(Path(args.input))


### PR DESCRIPTION
## Summary
Introduce initial stack-handshake contract artifacts for cross-skill interoperability.

## Changes
- add `contracts/stack-handshake.json`
- add `scripts/stack_contract.py`

## Why
This is a minimal, backward-compatible foundation for future stack coupling across planning/workflow/spec-tooling.

## Notes
- Scope intentionally small (2 files, 1 commit)
- No behavioral change to existing default user flow