### PR TITLE
feat(templates): add analytics workflow template

### DIFF
--- a/scripts/init-session.ps1
+++ b/scripts/init-session.ps1
@@ -1,17 +1,34 @@
 # Initialize planning files for a new session
-# Usage: .\init-session.ps1 [project-name]
+# Usage: .\init-session.ps1 [-Template TYPE] [project-name]
+# Templates: default, analytics
 
 param(
-    [string]$ProjectName = "project"
+    [string]$ProjectName = "project",
+    [string]$Template = "default"
 )
 
 $DATE = Get-Date -Format "yyyy-MM-dd"
 
-Write-Host "Initializing planning files for: $ProjectName"
+# Resolve template directory (skill root is one level up from scripts/)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillRoot = Split-Path -Parent $ScriptDir
+$TemplateDir = Join-Path $SkillRoot "templates"
+
+Write-Host "Initializing planning files for: $ProjectName (template: $Template)"
+
+# Validate template
+if ($Template -ne "default" -and $Template -ne "analytics") {
+    Write-Host "Unknown template: $Template (available: default, analytics). Using default."
+    $Template = "default"
+}
 
 # Create task_plan.md if it doesn't exist
 if (-not (Test-Path "task_plan.md")) {
-    @"
+    $AnalyticsPlan = Join-Path $TemplateDir "analytics_task_plan.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsPlan)) {
+        Copy-Item $AnalyticsPlan "task_plan.md"
+    } else {
+        @"
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,6 +73,7 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "task_plan.md" -Encoding UTF8
+    }
     Write-Host "Created task_plan.md"
 } else {
     Write-Host "task_plan.md already exists, skipping"
@@ -63,7 +81,11 @@ Phase 1
 
 # Create findings.md if it doesn't exist
 if (-not (Test-Path "findings.md")) {
-    @"
+    $AnalyticsFindings = Join-Path $TemplateDir "analytics_findings.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsFindings)) {
+        Copy-Item $AnalyticsFindings "findings.md"
+    } else {
+        @"
 # Findings & Decisions
 
 ## Requirements
@@ -83,6 +105,7 @@ if (-not (Test-Path "findings.md")) {
 ## Resources
 -
 "@ | Out-File -FilePath "findings.md" -Encoding UTF8
+    }
     Write-Host "Created findings.md"
 } else {
     Write-Host "findings.md already exists, skipping"
@@ -90,7 +113,29 @@ if (-not (Test-Path "findings.md")) {
 
 # Create progress.md if it doesn't exist
 if (-not (Test-Path "progress.md")) {
-    @"
+    if ($Template -eq "analytics") {
+        @"
+# Progress Log
+
+## Session: $DATE
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $DATE
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+"@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    } else {
+        @"
 # Progress Log
 
 ## Session: $DATE
@@ -110,6 +155,7 @@ if (-not (Test-Path "progress.md")) {
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    }
     Write-Host "Created progress.md"
 } else {
     Write-Host "progress.md already exists, skipping"

--- a/scripts/init-session.sh
+++ b/scripts/init-session.sh
@@ -1,17 +1,48 @@
 #!/bin/bash
 # Initialize planning files for a new session
-# Usage: ./init-session.sh [project-name]
+# Usage: ./init-session.sh [--template TYPE] [project-name]
+# Templates: default, analytics
 
 set -e
 
-PROJECT_NAME="${1:-project}"
+# Parse arguments
+TEMPLATE="default"
+PROJECT_NAME="project"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --template|-t)
+            TEMPLATE="$2"
+            shift 2
+            ;;
+        *)
+            PROJECT_NAME="$1"
+            shift
+            ;;
+    esac
+done
+
 DATE=$(date +%Y-%m-%d)
 
-echo "Initializing planning files for: $PROJECT_NAME"
+# Resolve template directory (skill root is one level up from scripts/)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_ROOT="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="$SKILL_ROOT/templates"
+
+echo "Initializing planning files for: $PROJECT_NAME (template: $TEMPLATE)"
+
+# Validate template
+if [ "$TEMPLATE" != "default" ] && [ "$TEMPLATE" != "analytics" ]; then
+    echo "Unknown template: $TEMPLATE (available: default, analytics). Using default."
+    TEMPLATE="default"
+fi
 
 # Create task_plan.md if it doesn't exist
 if [ ! -f "task_plan.md" ]; then
-    cat > task_plan.md << 'EOF'
+    if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_task_plan.md" ]; then
+        cp "$TEMPLATE_DIR/analytics_task_plan.md" task_plan.md
+    else
+        cat > task_plan.md << 'EOF'
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,6 +87,7 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 EOF
+    fi
     echo "Created task_plan.md"
 else
     echo "task_plan.md already exists, skipping"
@@ -63,7 +95,10 @@ fi
 
 # Create findings.md if it doesn't exist
 if [ ! -f "findings.md" ]; then
-    cat > findings.md << 'EOF'
+    if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_findings.md" ]; then
+        cp "$TEMPLATE_DIR/analytics_findings.md" findings.md
+    else
+        cat > findings.md << 'EOF'
 # Findings & Decisions
 
 ## Requirements
@@ -83,6 +118,7 @@ if [ ! -f "findings.md" ]; then
 ## Resources
 -
 EOF
+    fi
     echo "Created findings.md"
 else
     echo "findings.md already exists, skipping"
@@ -90,7 +126,29 @@ fi
 
 # Create progress.md if it doesn't exist
 if [ ! -f "progress.md" ]; then
-    cat > progress.md << EOF
+    if [ "$TEMPLATE" = "analytics" ]; then
+        cat > progress.md << EOF
+# Progress Log
+
+## Session: $DATE
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $DATE
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+EOF
+    else
+        cat > progress.md << EOF
 # Progress Log
 
 ## Session: $DATE
@@ -110,6 +168,7 @@ if [ ! -f "progress.md" ]; then
 | Error | Resolution |
 |-------|------------|
 EOF
+    fi
     echo "Created progress.md"
 else
     echo "progress.md already exists, skipping"

--- a/templates/analytics_findings.md
+++ b/templates/analytics_findings.md
@@ -1,0 +1,85 @@
+# Findings & Decisions
+<!--
+  WHAT: Knowledge base for your analytics session. Stores data sources, hypotheses, and results.
+  WHY: Context windows are limited. This file is your "external memory" for analytical work.
+  WHEN: Update after ANY discovery, especially after running queries or viewing charts.
+-->
+
+## Data Sources
+<!--
+  WHAT: Every data source you connected to, with schema details and quality notes.
+  WHY: Knowing where your data came from and its limitations is critical for reproducibility.
+  EXAMPLE:
+    | user_events | PostgreSQL prod replica | 2.3M rows | user_id, event_type, ts | 0.2% null user_id |
+    | revenue.csv | Finance team export | 45K rows | account_id, mrr, churn_date | Complete, no nulls |
+-->
+| Source | Location | Size | Key Fields | Quality Notes |
+|--------|----------|------|------------|---------------|
+|        |          |      |            |               |
+
+## Hypothesis Log
+<!--
+  WHAT: Each hypothesis you tested, the method used, and the result.
+  WHY: Structured tracking prevents p-hacking and makes your reasoning auditable.
+  EXAMPLE:
+    | H1: Churn > 50% for low-activity users | Chi-squared test | Confirmed (p=0.003) | High |
+    | H2: Feature X correlates with retention | Pearson correlation | Rejected (r=0.08) | High |
+-->
+| Hypothesis | Test Method | Result | Confidence |
+|------------|-------------|--------|------------|
+|            |             |        |            |
+
+## Query Results
+<!--
+  WHAT: Key queries you ran and what they revealed.
+  WHY: Queries are ephemeral - if you don't write down the results, they're lost on context reset.
+  WHEN: After EVERY significant query. Don't wait.
+  EXAMPLE:
+    ### Churn rate by activity segment
+    Query: SELECT activity_bucket, COUNT(*), AVG(churned) FROM user_segments GROUP BY 1
+    Result: Low activity: 62% churn, Medium: 28%, High: 8%
+    Interpretation: Strong inverse relationship between activity and churn
+-->
+<!-- Record query, result summary, and interpretation for each significant query -->
+
+## Statistical Findings
+<!--
+  WHAT: Formal statistical test results with all relevant metrics.
+  WHY: Recording p-values, effect sizes, and confidence intervals makes results reproducible.
+  EXAMPLE:
+    | Chi-squared (churn ~ activity) | p=0.003 | Cramer's V=0.31 | Reject null: activity segments differ significantly in churn |
+    | Pearson (feature_x ~ retention) | p=0.42 | r=0.08 | Fail to reject: no meaningful correlation |
+-->
+| Test | p-value | Effect Size | Conclusion |
+|------|---------|-------------|------------|
+|      |         |             |            |
+
+## Technical Decisions
+<!--
+  WHAT: Analytical method choices with reasoning.
+  EXAMPLE:
+    | Use log transform on revenue | Right-skewed distribution, normalizes for parametric tests |
+-->
+| Decision | Rationale |
+|----------|-----------|
+|          |           |
+
+## Issues Encountered
+| Issue | Resolution |
+|-------|------------|
+|       |            |
+
+## Resources
+<!-- URLs, file paths, documentation links -->
+-
+
+## Visual/Browser Findings
+<!--
+  CRITICAL: Update after viewing charts, dashboards, or browser results.
+  Multimodal content doesn't persist in context - capture as text immediately.
+-->
+-
+
+---
+*Update this file after every 2 view/browser/search operations*
+*This prevents visual information from being lost*

--- a/templates/analytics_task_plan.md
+++ b/templates/analytics_task_plan.md
@@ -1,0 +1,106 @@
+# Task Plan: [Analytics Project Description]
+<!--
+  WHAT: Roadmap for a data analytics or exploration session.
+  WHY: Analytics workflows have different phases than software development — hypothesis testing,
+       data quality checks, and statistical validation don't map to a generic build cycle.
+  WHEN: Create this FIRST before starting any data exploration. Update after each phase.
+-->
+
+## Goal
+<!--
+  WHAT: One clear sentence describing what you're trying to learn or produce.
+  EXAMPLE: "Determine which user segments have the highest churn risk using last 90 days of activity data."
+-->
+[One sentence describing the analytical objective]
+
+## Current Phase
+<!--
+  WHAT: Which phase you're currently working on (e.g., "Phase 1", "Phase 3").
+  WHY: Quick reference for where you are. Update this as you progress.
+-->
+Phase 1
+
+## Phases
+
+### Phase 1: Data Discovery
+<!--
+  WHAT: Connect to data sources, understand schemas, assess data quality.
+  WHY: Bad data produces bad analysis. This phase prevents wasted effort on unreliable inputs.
+-->
+- [ ] Identify and connect to data sources
+- [ ] Document schemas and field descriptions in findings.md
+- [ ] Assess data quality (nulls, duplicates, outliers, date ranges)
+- [ ] Estimate dataset size and query performance
+- **Status:** in_progress
+
+### Phase 2: Exploratory Analysis
+<!--
+  WHAT: Distributions, correlations, outliers, initial patterns.
+  WHY: Understanding the shape of your data before testing hypotheses prevents false conclusions.
+-->
+- [ ] Compute summary statistics for key variables
+- [ ] Visualize distributions and relationships
+- [ ] Identify outliers and anomalies
+- [ ] Document initial patterns in findings.md
+- **Status:** pending
+
+### Phase 3: Hypothesis Testing
+<!--
+  WHAT: Formalize hypotheses, run statistical tests, validate findings.
+  WHY: Moving from "it looks like X" to "we can confidently say X" requires structured testing.
+-->
+- [ ] Formalize hypotheses from exploratory phase
+- [ ] Select appropriate statistical tests
+- [ ] Run tests and record results in findings.md
+- [ ] Validate findings against holdout data or alternative methods
+- **Status:** pending
+
+### Phase 4: Synthesis & Reporting
+<!--
+  WHAT: Summarize findings, create visualizations, document conclusions.
+  WHY: Analysis without clear communication is wasted work. This phase produces the deliverable.
+-->
+- [ ] Summarize key findings with supporting evidence
+- [ ] Create final visualizations
+- [ ] Document conclusions and recommendations
+- [ ] Note limitations and areas for further investigation
+- **Status:** pending
+
+## Hypotheses
+<!--
+  WHAT: Questions you're investigating, stated as testable hypotheses.
+  WHY: Explicit hypotheses prevent fishing expeditions and keep analysis focused.
+  EXAMPLE:
+    1. Users who logged in < 3 times in the last 30 days have > 50% churn rate (H1)
+    2. Feature X adoption correlates with retention (r > 0.3) (H2)
+-->
+1. [Hypothesis to test]
+2. [Hypothesis to test]
+
+## Decisions Made
+<!--
+  WHAT: Analytical decisions with reasoning (e.g., choosing a test, filtering criteria).
+  EXAMPLE:
+    | Use median instead of mean | Revenue data is heavily right-skewed |
+    | Filter to last 90 days | Earlier data uses a different tracking schema |
+-->
+| Decision | Rationale |
+|----------|-----------|
+|          |           |
+
+## Errors Encountered
+<!--
+  WHAT: Every error you encounter, what attempt number it was, and how you resolved it.
+  EXAMPLE:
+    | Query timeout on raw table | 1 | Added date partition filter |
+    | Null join keys in user_events | 2 | Inner join instead of left join, documented data loss |
+-->
+| Error | Attempt | Resolution |
+|-------|---------|------------|
+|       | 1       |            |
+
+## Notes
+- Update phase status as you progress: pending -> in_progress -> complete
+- Re-read this plan before major analytical decisions
+- Log ALL errors - they help avoid repetition
+- Write query results and visual findings to findings.md immediately


### PR DESCRIPTION
## Summary

Adds an analytics-specific template set for data exploration workflows, plus a `--template` flag on `init-session.sh` / `init-session.ps1` to select it.

## Why

The existing templates assume a software dev workflow (Requirements, Planning, Implementation, Testing, Delivery). Analytics sessions have different phases and tracking needs. From your comment on #103:

> "Things like 'what data sources did I connect to,' 'what did the distribution look like,' 'which features mattered' need their own structure."

| Source | Signal |
|--------|--------|
| [#103](https://github.com/OthmanAdi/planning-with-files/issues/103) | Maintainer requested template ideas for analytics workflows |
| [#19](https://github.com/OthmanAdi/planning-with-files/issues/19) | Users asking how to adapt the skill for non-dev workflows |

## Changes

**New files:**
- `templates/analytics_task_plan.md` - 4-phase plan: Data Discovery, Exploratory Analysis, Hypothesis Testing, Synthesis & Reporting. Replaces "Key Questions" with a "Hypotheses" section. Uses the same `**Status:** pending/in_progress/complete` format so `check-complete.sh` works without modification.
- `templates/analytics_findings.md` - Replaces generic sections with: Data Sources table (source, location, size, key fields, quality notes), Hypothesis Log (hypothesis, test method, result, confidence), Query Results, and Statistical Findings (test, p-value, effect size, conclusion). Keeps Visual/Browser Findings for chart screenshots.

**Modified files:**
- `scripts/init-session.sh` - Added `--template` / `-t` flag. When `--template analytics` is passed, copies analytics templates. Default behavior unchanged. Also generates an analytics-specific `progress.md` with a Query Log table instead of Test Results.
- `scripts/init-session.ps1` - Same `-Template` parameter for Windows parity.

## Testing

Default path (no flag):
```
$ ./init-session.sh "test-project"
Initializing planning files for: test-project (template: default)
Created task_plan.md   # 5 phases, identical to current behavior
```

Analytics path:
```
$ ./init-session.sh --template analytics "user-churn-analysis"
Initializing planning files for: user-churn-analysis (template: analytics)
Created task_plan.md   # 4 phases: Data Discovery, Exploratory, Hypothesis, Synthesis
Created findings.md    # Data Sources, Hypothesis Log, Query Results, Statistical Findings
Created progress.md    # Query Log instead of Test Results
```

`check-complete.sh` compatibility:
```
$ bash scripts/check-complete.sh
[planning-with-files] Task in progress (0/4 phases complete).
[planning-with-files] 1 phase(s) still in progress.
[planning-with-files] 3 phase(s) pending.
```

Existing `tests/test_session_catchup.py` passes (1 pre-existing failure in Codex path test, unrelated to this change).

## Notes

- Templates follow the same HTML comment documentation style as the existing templates in `templates/`
- IDE-specific copies (`.cursor/`, `.gemini/`, etc.) will need syncing via `scripts/sync-ide-folders.py` after merge
- This opens the door for more domain templates (debugging, research) in future PRs

This contribution was developed with AI assistance (Claude Code).

Relates to #103