### PR TITLE
fix: wrap hook commands with sh -lc

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -85,9 +85,9 @@ Copy-Item templates\progress.md .
 
 The hooks use Unix-style commands. On Windows with Claude Code:
 
-- Hooks run in a Unix-compatible shell environment
-- Commands like `cat`, `head`, `echo` work automatically
-- No changes needed to the skill configuration
+- Hooks are dispatched through `sh -lc` so they behave consistently even when Claude Code launches them from PowerShell
+- Ensure Git Bash (or another `sh` implementation) is installed and available on your `PATH`
+- The Stop hook still prefers `check-complete.ps1` on Windows after the `sh` wrapper resolves the script path
 
 ---
 

--- a/skills/planning-with-files-zh/SKILL.md
+++ b/skills/planning-with-files-zh/SKILL.md
@@ -7,21 +7,21 @@ hooks:
   UserPromptSubmit:
     - hooks:
         - type: command
-          command: "if [ -f task_plan.md ]; then echo '[planning-with-files-zh] 检测到活跃计划。如果你在本次对话中还没有读取 task_plan.md、progress.md 和 findings.md，请立即读取。'; fi"
+          command: "sh -lc 'if [ -f task_plan.md ]; then echo \"[planning-with-files-zh] 检测到活跃计划。如果你在本次对话中还没有读取 task_plan.md、progress.md 和 findings.md，请立即读取。\"; fi'"
   PreToolUse:
     - matcher: "Write|Edit|Bash|Read|Glob|Grep"
       hooks:
         - type: command
-          command: "cat task_plan.md 2>/dev/null | head -30 || true"
+          command: "sh -lc 'cat task_plan.md 2>/dev/null | head -30 || true'"
   PostToolUse:
     - matcher: "Write|Edit"
       hooks:
         - type: command
-          command: "if [ -f task_plan.md ]; then echo '[planning-with-files-zh] 请更新 progress.md 记录你刚才做了什么。如果某个阶段已完成，请更新 task_plan.md 的状态。'; fi"
+          command: "sh -lc 'if [ -f task_plan.md ]; then echo \"[planning-with-files-zh] 请更新 progress.md 记录你刚才做了什么。如果某个阶段已完成，请更新 task_plan.md 的状态。\"; fi'"
   Stop:
     - hooks:
         - type: command
-          command: "SD=\"${CLAUDE_SKILL_DIR:-${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files-zh}}/scripts\"; powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"$SD/check-complete.ps1\" 2>/dev/null || sh \"$SD/check-complete.sh\""
+          command: "sh -lc 'SD=\"${CLAUDE_SKILL_DIR:-${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files-zh}}/scripts\"; powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"$SD/check-complete.ps1\" 2>/dev/null || sh \"$SD/check-complete.sh\"'"
 metadata:
   version: "2.30.0"
 ---

--- a/skills/planning-with-files-zht/SKILL.md
+++ b/skills/planning-with-files-zht/SKILL.md
@@ -7,21 +7,21 @@ hooks:
   UserPromptSubmit:
     - hooks:
         - type: command
-          command: "if [ -f task_plan.md ]; then echo '[planning-with-files-zht] 偵測到活躍計畫。如果你在本次對話中還沒有讀取 task_plan.md、progress.md 和 findings.md，請立即讀取。'; fi"
+          command: "sh -lc 'if [ -f task_plan.md ]; then echo \"[planning-with-files-zht] 偵測到活躍計畫。如果你在本次對話中還沒有讀取 task_plan.md、progress.md 和 findings.md，請立即讀取。\"; fi'"
   PreToolUse:
     - matcher: "Write|Edit|Bash|Read|Glob|Grep"
       hooks:
         - type: command
-          command: "cat task_plan.md 2>/dev/null | head -30 || true"
+          command: "sh -lc 'cat task_plan.md 2>/dev/null | head -30 || true'"
   PostToolUse:
     - matcher: "Write|Edit"
       hooks:
         - type: command
-          command: "if [ -f task_plan.md ]; then echo '[planning-with-files-zht] 請更新 progress.md 記錄你剛才做了什麼。如果某個階段已完成，請更新 task_plan.md 的狀態。'; fi"
+          command: "sh -lc 'if [ -f task_plan.md ]; then echo \"[planning-with-files-zht] 請更新 progress.md 記錄你剛才做了什麼。如果某個階段已完成，請更新 task_plan.md 的狀態。\"; fi'"
   Stop:
     - hooks:
         - type: command
-          command: "SD=\"${CLAUDE_SKILL_DIR:-${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files-zht}}/scripts\"; powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"$SD/check-complete.ps1\" 2>/dev/null || sh \"$SD/check-complete.sh\""
+          command: "sh -lc 'SD=\"${CLAUDE_SKILL_DIR:-${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files-zht}}/scripts\"; powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"$SD/check-complete.ps1\" 2>/dev/null || sh \"$SD/check-complete.sh\"'"
 metadata:
   version: "2.30.0"
 ---

--- a/skills/planning-with-files/SKILL.md
+++ b/skills/planning-with-files/SKILL.md
@@ -7,21 +7,21 @@ hooks:
   UserPromptSubmit:
     - hooks:
         - type: command
-          command: "if [ -f task_plan.md ]; then echo '[planning-with-files] ACTIVE PLAN — current state:'; head -50 task_plan.md; echo ''; echo '=== recent progress ==='; tail -20 progress.md 2>/dev/null; echo ''; echo '[planning-with-files] Read findings.md for research context. Continue from the current phase.'; fi"
+          command: "sh -lc 'if [ -f task_plan.md ]; then echo \"[planning-with-files] ACTIVE PLAN — current state:\"; head -50 task_plan.md; echo \"\"; echo \"=== recent progress ===\"; tail -20 progress.md 2>/dev/null; echo \"\"; echo \"[planning-with-files] Read findings.md for research context. Continue from the current phase.\"; fi'"
   PreToolUse:
     - matcher: "Write|Edit|Bash|Read|Glob|Grep"
       hooks:
         - type: command
-          command: "cat task_plan.md 2>/dev/null | head -30 || true"
+          command: "sh -lc 'cat task_plan.md 2>/dev/null | head -30 || true'"
   PostToolUse:
     - matcher: "Write|Edit"
       hooks:
         - type: command
-          command: "if [ -f task_plan.md ]; then echo '[planning-with-files] Update progress.md with what you just did. If a phase is now complete, update task_plan.md status.'; fi"
+          command: "sh -lc 'if [ -f task_plan.md ]; then echo \"[planning-with-files] Update progress.md with what you just did. If a phase is now complete, update task_plan.md status.\"; fi'"
   Stop:
     - hooks:
         - type: command
-          command: "SD=\"${CLAUDE_SKILL_DIR:-${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files}}/scripts\"; powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"$SD/check-complete.ps1\" 2>/dev/null || sh \"$SD/check-complete.sh\""
+          command: "sh -lc 'SD=\"${CLAUDE_SKILL_DIR:-${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files}}/scripts\"; powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"$SD/check-complete.ps1\" 2>/dev/null || sh \"$SD/check-complete.sh\"'"
 metadata:
   version: "2.30.0"
 ---

--- a/tests/test_hook_commands.py
+++ b/tests/test_hook_commands.py
@@ -1,0 +1,33 @@
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_FILES = [
+    REPO_ROOT / "skills/planning-with-files/SKILL.md",
+    REPO_ROOT / "skills/planning-with-files-zh/SKILL.md",
+    REPO_ROOT / "skills/planning-with-files-zht/SKILL.md",
+]
+
+
+def extract_commands(skill_path: Path) -> list[str]:
+    text = skill_path.read_text(encoding="utf-8")
+    return re.findall(r'^\s*command: "(.*)"\s*$', text, re.MULTILINE)
+
+
+class HookCommandTests(unittest.TestCase):
+    def test_all_hook_commands_dispatch_through_sh(self) -> None:
+        for skill_path in SKILL_FILES:
+            with self.subTest(skill=str(skill_path.relative_to(REPO_ROOT))):
+                commands = extract_commands(skill_path)
+                self.assertTrue(commands, "expected at least one hook command")
+                for command in commands:
+                    self.assertTrue(
+                        command.startswith("sh -lc "),
+                        f"hook command should dispatch through sh -lc: {command}",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- wrap the English, Simplified Chinese, and Traditional Chinese hook commands with `sh -lc`
- add a regression test that keeps all hook command entries on the same launcher path
- update the Windows docs to call out the `sh` / Git Bash requirement explicitly

## Why
Fixes #32.

Recent Windows reports show Claude Code can launch hook commands from PowerShell. When that happens, the current hook strings are parsed by the host shell before `check-complete.ps1` ever runs, so POSIX-only syntax like `SD=...` and `${VAR:-fallback}` can fail early. Routing the hook commands through `sh -lc` keeps the existing shell snippets intact while making the launcher behavior consistent.

## Validation
- `python3 -m unittest tests.test_hook_commands -v`
- `python3 tests/test_path_fix.py`
- `python3 -m unittest discover -s tests -v` *(still fails on the pre-existing `tests.test_session_catchup.SessionCatchupCodexTests.test_codex_variant_uses_claude_path_when_project_exists` baseline, unrelated to this PR)*
- `CLAUDE_SKILL_DIR="$(pwd)/skills/planning-with-files" /bin/sh -lc 'SD="${CLAUDE_SKILL_DIR:-${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files}}/scripts"; powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$SD/check-complete.ps1" 2>/dev/null || sh "$SD/check-complete.sh"'`
