### PR TITLE
fix: correct PowerShell syntax in Pi session-catchup invocation

### DIFF
--- a/.pi/skills/planning-with-files/SKILL.md
+++ b/.pi/skills/planning-with-files/SKILL.md
@@ -20,7 +20,7 @@ python scripts/session-catchup.py "$(pwd)"
 
 ```powershell
 # Windows PowerShell
-python scripts\session-catchup.py" (Get-Location)
+python "scripts\session-catchup.py" (Get-Location)
 ```
 
 **If you cannot find the script:**


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

In `.pi/skills/planning-with-files/SKILL.md`, the Windows PowerShell invocation of `session-catchup.py` has a syntax error — the opening `"` before the script path is missing:

**Before (broken):**
\`\`\`powershell
python scripts\session-catchup.py" (Get-Location)
\`\`\`

**After (fixed):**
\`\`\`powershell
python "scripts\session-catchup.py" (Get-Location)
\`\`\`

## Impact

Windows users following the Pi skill's session-catchup instructions get a PowerShell parse error. The command silently fails, so the previous session's context is never recovered. This affects only the Pi-specific skill variant.

## Fix

Added the missing opening `"` to balance the closing `"`. The fix maintains the relative path approach used by the Pi variant (consistent with its bash counterpart on line 18).