### PR TITLE
fix: cap session-catchup output before injecting into model context

### DIFF
--- a/.github/hooks/scripts/session-start.sh
+++ b/.github/hooks/scripts/session-start.sh
@@ -15,11 +15,12 @@ if [ -f "$PLAN_FILE" ]; then
     # Plan exists — try session catchup, fall back to reading plan header
     CATCHUP=""
     if [ -n "$PYTHON" ] && [ -f "$SKILL_DIR/scripts/session-catchup.py" ]; then
-        CATCHUP=$($PYTHON "$SKILL_DIR/scripts/session-catchup.py" "$(pwd)" 2>/dev/null)
+        CATCHUP=$($PYTHON "$SKILL_DIR/scripts/session-catchup.py" "$(pwd)" 2>/dev/null | head -100)
     fi
 
     if [ -n "$CATCHUP" ]; then
-        CONTEXT="$CATCHUP"
+        CONTEXT="[planning-with-files] Previous session context (truncated to 100 lines):
+$CATCHUP"
     else
         CONTEXT=$(head -5 "$PLAN_FILE" 2>/dev/null || echo "")
     fi


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Issue (Medium Severity)

In `.github/hooks/scripts/session-start.sh`, the session-start hook runs `session-catchup.py` and injects its **full, unbounded output** verbatim as `additionalContext` into the model context. Prior session content can include arbitrary user messages and web/search results from previous sessions, with no size limit and no label indicating this is historical content.

This is a medium-severity concern: maliciously crafted content saved in a previous session (e.g., from a web search result) could influence the current session's model context without the user being aware.

## Fix

Two minimal changes to `session-start.sh`:

1. **Size cap**: Pipe `session-catchup.py` output through `head -100` to limit injection to 100 lines maximum.
2. **Prefix label**: Prepend `[planning-with-files] Previous session context (truncated to 100 lines):` so the model knows this content originates from a previous session, not the current one.

```diff
-        CATCHUP=$($PYTHON "$SKILL_DIR/scripts/session-catchup.py" "$(pwd)" 2>/dev/null)
+        CATCHUP=$($PYTHON "$SKILL_DIR/scripts/session-catchup.py" "$(pwd)" 2>/dev/null | head -100)
 
     if [ -n "$CATCHUP" ]; then
-        CONTEXT="$CATCHUP"
+        CONTEXT="[planning-with-files] Previous session context (truncated to 100 lines):
+$CATCHUP"
```

The fix is backward-compatible: normal session-catchup output is well under 100 lines, so legitimate use is unaffected.