### PR TITLE
fix(scripts): propagate v2.36.0 slug-mode init-session to canonical skill copy + IDE folders

### DIFF
--- a/.codebuddy/skills/planning-with-files/scripts/check-complete.sh
+++ b/.codebuddy/skills/planning-with-files/scripts/check-complete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check if all phases in task_plan.md are complete
 # Always exits 0 — uses stdout for status reporting
 # Used by Stop hook to report task completion status

--- a/.codebuddy/skills/planning-with-files/scripts/init-session.ps1
+++ b/.codebuddy/skills/planning-with-files/scripts/init-session.ps1
@@ -1,17 +1,34 @@
 # Initialize planning files for a new session
-# Usage: .\init-session.ps1 [project-name]
+# Usage: .\init-session.ps1 [-Template TYPE] [project-name]
+# Templates: default, analytics
 
 param(
-    [string]$ProjectName = "project"
+    [string]$ProjectName = "project",
+    [string]$Template = "default"
 )
 
 $DATE = Get-Date -Format "yyyy-MM-dd"
 
-Write-Host "Initializing planning files for: $ProjectName"
+# Resolve template directory (skill root is one level up from scripts/)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillRoot = Split-Path -Parent $ScriptDir
+$TemplateDir = Join-Path $SkillRoot "templates"
+
+Write-Host "Initializing planning files for: $ProjectName (template: $Template)"
+
+# Validate template
+if ($Template -ne "default" -and $Template -ne "analytics") {
+    Write-Host "Unknown template: $Template (available: default, analytics). Using default."
+    $Template = "default"
+}
 
 # Create task_plan.md if it doesn't exist
 if (-not (Test-Path "task_plan.md")) {
-    @"
+    $AnalyticsPlan = Join-Path $TemplateDir "analytics_task_plan.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsPlan)) {
+        Copy-Item $AnalyticsPlan "task_plan.md"
+    } else {
+        @"
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,6 +73,7 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "task_plan.md" -Encoding UTF8
+    }
     Write-Host "Created task_plan.md"
 } else {
     Write-Host "task_plan.md already exists, skipping"
@@ -63,7 +81,11 @@ Phase 1
 
 # Create findings.md if it doesn't exist
 if (-not (Test-Path "findings.md")) {
-    @"
+    $AnalyticsFindings = Join-Path $TemplateDir "analytics_findings.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsFindings)) {
+        Copy-Item $AnalyticsFindings "findings.md"
+    } else {
+        @"
 # Findings & Decisions
 
 ## Requirements
@@ -83,6 +105,7 @@ if (-not (Test-Path "findings.md")) {
 ## Resources
 -
 "@ | Out-File -FilePath "findings.md" -Encoding UTF8
+    }
     Write-Host "Created findings.md"
 } else {
     Write-Host "findings.md already exists, skipping"
@@ -90,7 +113,29 @@ if (-not (Test-Path "findings.md")) {
 
 # Create progress.md if it doesn't exist
 if (-not (Test-Path "progress.md")) {
-    @"
+    if ($Template -eq "analytics") {
+        @"
+# Progress Log
+
+## Session: $DATE
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $DATE
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+"@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    } else {
+        @"
 # Progress Log
 
 ## Session: $DATE
@@ -110,6 +155,7 @@ if (-not (Test-Path "progress.md")) {
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    }
     Write-Host "Created progress.md"
 } else {
     Write-Host "progress.md already exists, skipping"

--- a/.codebuddy/skills/planning-with-files/scripts/init-session.sh
+++ b/.codebuddy/skills/planning-with-files/scripts/init-session.sh
@@ -1,17 +1,96 @@
-#!/bin/bash
-# Initialize planning files for a new session
-# Usage: ./init-session.sh [project-name]
+#!/usr/bin/env bash
+# Initialize planning files for a new session.
+#
+# Usage:
+#   ./init-session.sh                              # legacy: root-level task_plan.md, findings.md, progress.md
+#   ./init-session.sh [--template TYPE]            # legacy with template choice
+#   ./init-session.sh "Backend Refactor"           # slug mode: .planning/<date>-backend-refactor/
+#   ./init-session.sh --plan-dir                   # slug mode with auto-generated untitled-<short> name
+#   ./init-session.sh --plan-dir "Quick Spike"     # slug mode, explicit slug
+#
+# Legacy mode (zero positional args, no --plan-dir) preserves v1.x behavior so
+# upgrades stay non-breaking. Slug mode addresses parallel multi-task isolation
+# (issue #148) by writing each plan under .planning/<date>-<slug>/ and pinning
+# .planning/.active_plan so resolve-plan-dir.sh can find it.
 
 set -e
 
-PROJECT_NAME="${1:-project}"
+TEMPLATE="default"
+PROJECT_NAME=""
+USE_PLAN_DIR=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --template|-t)
+            TEMPLATE="$2"
+            shift 2
+            ;;
+        --plan-dir)
+            USE_PLAN_DIR=1
+            shift
+            ;;
+        *)
+            if [ -z "$PROJECT_NAME" ]; then
+                PROJECT_NAME="$1"
+            else
+                PROJECT_NAME="$PROJECT_NAME $1"
+            fi
+            shift
+            ;;
+    esac
+done
+
 DATE=$(date +%Y-%m-%d)
 
-echo "Initializing planning files for: $PROJECT_NAME"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_ROOT="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="$SKILL_ROOT/templates"
 
-# Create task_plan.md if it doesn't exist
-if [ ! -f "task_plan.md" ]; then
-    cat > task_plan.md << 'EOF'
+if [ "$TEMPLATE" != "default" ] && [ "$TEMPLATE" != "analytics" ]; then
+    echo "Unknown template: $TEMPLATE (available: default, analytics). Using default."
+    TEMPLATE="default"
+fi
+
+# Slug mode triggers when a project name was given OR --plan-dir was passed.
+SLUG_MODE=0
+if [ -n "$PROJECT_NAME" ] || [ "$USE_PLAN_DIR" -eq 1 ]; then
+    SLUG_MODE=1
+fi
+
+slugify() {
+    # Lowercase, non-alphanumerics → '-', collapse repeats, trim leading/trailing '-'
+    printf '%s' "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -e 's/[^a-z0-9]/-/g' -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//' \
+        | cut -c1-40
+}
+
+short_uuid() {
+    # Probe each candidate: command -v alone is not enough on Windows because
+    # App Execution Aliases report presence but exit non-zero when run.
+    _py="${PYTHON_BIN:-}"
+    if [ -z "$_py" ]; then
+        for _c in python3 python py; do
+            if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "import uuid" >/dev/null 2>&1; then
+                _py="$_c"
+                break
+            fi
+        done
+    fi
+    if [ -n "$_py" ]; then
+        "$_py" -c "import uuid; print(uuid.uuid4().hex[:8])"
+        return
+    fi
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-' | cut -c1-8
+        return
+    fi
+    # Last-ditch: seconds timestamp as 8 hex chars
+    printf '%08x' "$(date +%s)" | cut -c1-8
+}
+
+write_default_task_plan() {
+    cat > "$1" << 'EOF'
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,14 +135,10 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created task_plan.md"
-else
-    echo "task_plan.md already exists, skipping"
-fi
+}
 
-# Create findings.md if it doesn't exist
-if [ ! -f "findings.md" ]; then
-    cat > findings.md << 'EOF'
+write_default_findings() {
+    cat > "$1" << 'EOF'
 # Findings & Decisions
 
 ## Requirements
@@ -83,21 +158,19 @@ if [ ! -f "findings.md" ]; then
 ## Resources
 -
 EOF
-    echo "Created findings.md"
-else
-    echo "findings.md already exists, skipping"
-fi
+}
 
-# Create progress.md if it doesn't exist
-if [ ! -f "progress.md" ]; then
-    cat > progress.md << EOF
+write_default_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
 # Progress Log
 
-## Session: $DATE
+## Session: $date_value
 
 ### Current Status
 - **Phase:** 1 - Requirements & Discovery
-- **Started:** $DATE
+- **Started:** $date_value
 
 ### Actions Taken
 -
@@ -110,11 +183,102 @@ if [ ! -f "progress.md" ]; then
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created progress.md"
-else
-    echo "progress.md already exists, skipping"
-fi
+}
 
-echo ""
-echo "Planning files initialized!"
-echo "Files: task_plan.md, findings.md, progress.md"
+write_analytics_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
+# Progress Log
+
+## Session: $date_value
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $date_value
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+EOF
+}
+
+create_files_in() {
+    local target_dir="$1"
+    local plan_path="$target_dir/task_plan.md"
+    local findings_path="$target_dir/findings.md"
+    local progress_path="$target_dir/progress.md"
+
+    if [ ! -f "$plan_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_task_plan.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_task_plan.md" "$plan_path"
+        else
+            write_default_task_plan "$plan_path"
+        fi
+        echo "Created $plan_path"
+    else
+        echo "$plan_path already exists, skipping"
+    fi
+
+    if [ ! -f "$findings_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_findings.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_findings.md" "$findings_path"
+        else
+            write_default_findings "$findings_path"
+        fi
+        echo "Created $findings_path"
+    else
+        echo "$findings_path already exists, skipping"
+    fi
+
+    if [ ! -f "$progress_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ]; then
+            write_analytics_progress "$DATE" "$progress_path"
+        else
+            write_default_progress "$DATE" "$progress_path"
+        fi
+        echo "Created $progress_path"
+    else
+        echo "$progress_path already exists, skipping"
+    fi
+}
+
+if [ "$SLUG_MODE" -eq 1 ]; then
+    SLUG="$(slugify "$PROJECT_NAME")"
+    if [ -z "$SLUG" ]; then
+        SLUG="untitled-$(short_uuid)"
+    fi
+    BASE_ID="${DATE}-${SLUG}"
+    PLAN_ID="$BASE_ID"
+    PLAN_ROOT="${PWD}/.planning"
+    counter=2
+    while [ -d "${PLAN_ROOT}/${PLAN_ID}" ]; do
+        PLAN_ID="${BASE_ID}-${counter}"
+        counter=$((counter + 1))
+    done
+    PLAN_DIR="${PLAN_ROOT}/${PLAN_ID}"
+    mkdir -p "$PLAN_DIR"
+
+    echo "Initializing planning files for: ${PROJECT_NAME:-untitled} (template: $TEMPLATE)"
+    echo "PLAN_ID=$PLAN_ID"
+    create_files_in "$PLAN_DIR"
+    printf "%s\n" "$PLAN_ID" > "${PLAN_ROOT}/.active_plan"
+    echo ""
+    echo "Active plan recorded: ${PLAN_ROOT}/.active_plan"
+    echo "Pin this terminal to the plan for parallel sessions:"
+    echo "  export PLAN_ID=$PLAN_ID"
+else
+    PROJECT_NAME="${PROJECT_NAME:-project}"
+    echo "Initializing planning files for: $PROJECT_NAME (template: $TEMPLATE)"
+    create_files_in "$(pwd)"
+    echo ""
+    echo "Planning files initialized!"
+    echo "Files: task_plan.md, findings.md, progress.md"
+fi

--- a/.codex/skills/planning-with-files/scripts/check-complete.sh
+++ b/.codex/skills/planning-with-files/scripts/check-complete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check if all phases in task_plan.md are complete
 # Always exits 0 — uses stdout for status reporting
 # Used by Stop hook to report task completion status

--- a/.codex/skills/planning-with-files/scripts/init-session.ps1
+++ b/.codex/skills/planning-with-files/scripts/init-session.ps1
@@ -1,17 +1,34 @@
 # Initialize planning files for a new session
-# Usage: .\init-session.ps1 [project-name]
+# Usage: .\init-session.ps1 [-Template TYPE] [project-name]
+# Templates: default, analytics
 
 param(
-    [string]$ProjectName = "project"
+    [string]$ProjectName = "project",
+    [string]$Template = "default"
 )
 
 $DATE = Get-Date -Format "yyyy-MM-dd"
 
-Write-Host "Initializing planning files for: $ProjectName"
+# Resolve template directory (skill root is one level up from scripts/)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillRoot = Split-Path -Parent $ScriptDir
+$TemplateDir = Join-Path $SkillRoot "templates"
+
+Write-Host "Initializing planning files for: $ProjectName (template: $Template)"
+
+# Validate template
+if ($Template -ne "default" -and $Template -ne "analytics") {
+    Write-Host "Unknown template: $Template (available: default, analytics). Using default."
+    $Template = "default"
+}
 
 # Create task_plan.md if it doesn't exist
 if (-not (Test-Path "task_plan.md")) {
-    @"
+    $AnalyticsPlan = Join-Path $TemplateDir "analytics_task_plan.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsPlan)) {
+        Copy-Item $AnalyticsPlan "task_plan.md"
+    } else {
+        @"
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,6 +73,7 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "task_plan.md" -Encoding UTF8
+    }
     Write-Host "Created task_plan.md"
 } else {
     Write-Host "task_plan.md already exists, skipping"
@@ -63,7 +81,11 @@ Phase 1
 
 # Create findings.md if it doesn't exist
 if (-not (Test-Path "findings.md")) {
-    @"
+    $AnalyticsFindings = Join-Path $TemplateDir "analytics_findings.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsFindings)) {
+        Copy-Item $AnalyticsFindings "findings.md"
+    } else {
+        @"
 # Findings & Decisions
 
 ## Requirements
@@ -83,6 +105,7 @@ if (-not (Test-Path "findings.md")) {
 ## Resources
 -
 "@ | Out-File -FilePath "findings.md" -Encoding UTF8
+    }
     Write-Host "Created findings.md"
 } else {
     Write-Host "findings.md already exists, skipping"
@@ -90,7 +113,29 @@ if (-not (Test-Path "findings.md")) {
 
 # Create progress.md if it doesn't exist
 if (-not (Test-Path "progress.md")) {
-    @"
+    if ($Template -eq "analytics") {
+        @"
+# Progress Log
+
+## Session: $DATE
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $DATE
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+"@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    } else {
+        @"
 # Progress Log
 
 ## Session: $DATE
@@ -110,6 +155,7 @@ if (-not (Test-Path "progress.md")) {
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    }
     Write-Host "Created progress.md"
 } else {
     Write-Host "progress.md already exists, skipping"

--- a/.codex/skills/planning-with-files/scripts/init-session.sh
+++ b/.codex/skills/planning-with-files/scripts/init-session.sh
@@ -1,17 +1,96 @@
-#!/bin/bash
-# Initialize planning files for a new session
-# Usage: ./init-session.sh [project-name]
+#!/usr/bin/env bash
+# Initialize planning files for a new session.
+#
+# Usage:
+#   ./init-session.sh                              # legacy: root-level task_plan.md, findings.md, progress.md
+#   ./init-session.sh [--template TYPE]            # legacy with template choice
+#   ./init-session.sh "Backend Refactor"           # slug mode: .planning/<date>-backend-refactor/
+#   ./init-session.sh --plan-dir                   # slug mode with auto-generated untitled-<short> name
+#   ./init-session.sh --plan-dir "Quick Spike"     # slug mode, explicit slug
+#
+# Legacy mode (zero positional args, no --plan-dir) preserves v1.x behavior so
+# upgrades stay non-breaking. Slug mode addresses parallel multi-task isolation
+# (issue #148) by writing each plan under .planning/<date>-<slug>/ and pinning
+# .planning/.active_plan so resolve-plan-dir.sh can find it.
 
 set -e
 
-PROJECT_NAME="${1:-project}"
+TEMPLATE="default"
+PROJECT_NAME=""
+USE_PLAN_DIR=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --template|-t)
+            TEMPLATE="$2"
+            shift 2
+            ;;
+        --plan-dir)
+            USE_PLAN_DIR=1
+            shift
+            ;;
+        *)
+            if [ -z "$PROJECT_NAME" ]; then
+                PROJECT_NAME="$1"
+            else
+                PROJECT_NAME="$PROJECT_NAME $1"
+            fi
+            shift
+            ;;
+    esac
+done
+
 DATE=$(date +%Y-%m-%d)
 
-echo "Initializing planning files for: $PROJECT_NAME"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_ROOT="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="$SKILL_ROOT/templates"
 
-# Create task_plan.md if it doesn't exist
-if [ ! -f "task_plan.md" ]; then
-    cat > task_plan.md << 'EOF'
+if [ "$TEMPLATE" != "default" ] && [ "$TEMPLATE" != "analytics" ]; then
+    echo "Unknown template: $TEMPLATE (available: default, analytics). Using default."
+    TEMPLATE="default"
+fi
+
+# Slug mode triggers when a project name was given OR --plan-dir was passed.
+SLUG_MODE=0
+if [ -n "$PROJECT_NAME" ] || [ "$USE_PLAN_DIR" -eq 1 ]; then
+    SLUG_MODE=1
+fi
+
+slugify() {
+    # Lowercase, non-alphanumerics → '-', collapse repeats, trim leading/trailing '-'
+    printf '%s' "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -e 's/[^a-z0-9]/-/g' -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//' \
+        | cut -c1-40
+}
+
+short_uuid() {
+    # Probe each candidate: command -v alone is not enough on Windows because
+    # App Execution Aliases report presence but exit non-zero when run.
+    _py="${PYTHON_BIN:-}"
+    if [ -z "$_py" ]; then
+        for _c in python3 python py; do
+            if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "import uuid" >/dev/null 2>&1; then
+                _py="$_c"
+                break
+            fi
+        done
+    fi
+    if [ -n "$_py" ]; then
+        "$_py" -c "import uuid; print(uuid.uuid4().hex[:8])"
+        return
+    fi
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-' | cut -c1-8
+        return
+    fi
+    # Last-ditch: seconds timestamp as 8 hex chars
+    printf '%08x' "$(date +%s)" | cut -c1-8
+}
+
+write_default_task_plan() {
+    cat > "$1" << 'EOF'
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,14 +135,10 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created task_plan.md"
-else
-    echo "task_plan.md already exists, skipping"
-fi
+}
 
-# Create findings.md if it doesn't exist
-if [ ! -f "findings.md" ]; then
-    cat > findings.md << 'EOF'
+write_default_findings() {
+    cat > "$1" << 'EOF'
 # Findings & Decisions
 
 ## Requirements
@@ -83,21 +158,19 @@ if [ ! -f "findings.md" ]; then
 ## Resources
 -
 EOF
-    echo "Created findings.md"
-else
-    echo "findings.md already exists, skipping"
-fi
+}
 
-# Create progress.md if it doesn't exist
-if [ ! -f "progress.md" ]; then
-    cat > progress.md << EOF
+write_default_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
 # Progress Log
 
-## Session: $DATE
+## Session: $date_value
 
 ### Current Status
 - **Phase:** 1 - Requirements & Discovery
-- **Started:** $DATE
+- **Started:** $date_value
 
 ### Actions Taken
 -
@@ -110,11 +183,102 @@ if [ ! -f "progress.md" ]; then
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created progress.md"
-else
-    echo "progress.md already exists, skipping"
-fi
+}
 
-echo ""
-echo "Planning files initialized!"
-echo "Files: task_plan.md, findings.md, progress.md"
+write_analytics_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
+# Progress Log
+
+## Session: $date_value
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $date_value
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+EOF
+}
+
+create_files_in() {
+    local target_dir="$1"
+    local plan_path="$target_dir/task_plan.md"
+    local findings_path="$target_dir/findings.md"
+    local progress_path="$target_dir/progress.md"
+
+    if [ ! -f "$plan_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_task_plan.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_task_plan.md" "$plan_path"
+        else
+            write_default_task_plan "$plan_path"
+        fi
+        echo "Created $plan_path"
+    else
+        echo "$plan_path already exists, skipping"
+    fi
+
+    if [ ! -f "$findings_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_findings.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_findings.md" "$findings_path"
+        else
+            write_default_findings "$findings_path"
+        fi
+        echo "Created $findings_path"
+    else
+        echo "$findings_path already exists, skipping"
+    fi
+
+    if [ ! -f "$progress_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ]; then
+            write_analytics_progress "$DATE" "$progress_path"
+        else
+            write_default_progress "$DATE" "$progress_path"
+        fi
+        echo "Created $progress_path"
+    else
+        echo "$progress_path already exists, skipping"
+    fi
+}
+
+if [ "$SLUG_MODE" -eq 1 ]; then
+    SLUG="$(slugify "$PROJECT_NAME")"
+    if [ -z "$SLUG" ]; then
+        SLUG="untitled-$(short_uuid)"
+    fi
+    BASE_ID="${DATE}-${SLUG}"
+    PLAN_ID="$BASE_ID"
+    PLAN_ROOT="${PWD}/.planning"
+    counter=2
+    while [ -d "${PLAN_ROOT}/${PLAN_ID}" ]; do
+        PLAN_ID="${BASE_ID}-${counter}"
+        counter=$((counter + 1))
+    done
+    PLAN_DIR="${PLAN_ROOT}/${PLAN_ID}"
+    mkdir -p "$PLAN_DIR"
+
+    echo "Initializing planning files for: ${PROJECT_NAME:-untitled} (template: $TEMPLATE)"
+    echo "PLAN_ID=$PLAN_ID"
+    create_files_in "$PLAN_DIR"
+    printf "%s\n" "$PLAN_ID" > "${PLAN_ROOT}/.active_plan"
+    echo ""
+    echo "Active plan recorded: ${PLAN_ROOT}/.active_plan"
+    echo "Pin this terminal to the plan for parallel sessions:"
+    echo "  export PLAN_ID=$PLAN_ID"
+else
+    PROJECT_NAME="${PROJECT_NAME:-project}"
+    echo "Initializing planning files for: $PROJECT_NAME (template: $TEMPLATE)"
+    create_files_in "$(pwd)"
+    echo ""
+    echo "Planning files initialized!"
+    echo "Files: task_plan.md, findings.md, progress.md"
+fi

--- a/.continue/skills/planning-with-files/scripts/check-complete.sh
+++ b/.continue/skills/planning-with-files/scripts/check-complete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check if all phases in task_plan.md are complete
 # Always exits 0 — uses stdout for status reporting
 # Used by Stop hook to report task completion status

--- a/.continue/skills/planning-with-files/scripts/init-session.ps1
+++ b/.continue/skills/planning-with-files/scripts/init-session.ps1
@@ -1,17 +1,34 @@
 # Initialize planning files for a new session
-# Usage: .\init-session.ps1 [project-name]
+# Usage: .\init-session.ps1 [-Template TYPE] [project-name]
+# Templates: default, analytics
 
 param(
-    [string]$ProjectName = "project"
+    [string]$ProjectName = "project",
+    [string]$Template = "default"
 )
 
 $DATE = Get-Date -Format "yyyy-MM-dd"
 
-Write-Host "Initializing planning files for: $ProjectName"
+# Resolve template directory (skill root is one level up from scripts/)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillRoot = Split-Path -Parent $ScriptDir
+$TemplateDir = Join-Path $SkillRoot "templates"
+
+Write-Host "Initializing planning files for: $ProjectName (template: $Template)"
+
+# Validate template
+if ($Template -ne "default" -and $Template -ne "analytics") {
+    Write-Host "Unknown template: $Template (available: default, analytics). Using default."
+    $Template = "default"
+}
 
 # Create task_plan.md if it doesn't exist
 if (-not (Test-Path "task_plan.md")) {
-    @"
+    $AnalyticsPlan = Join-Path $TemplateDir "analytics_task_plan.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsPlan)) {
+        Copy-Item $AnalyticsPlan "task_plan.md"
+    } else {
+        @"
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,6 +73,7 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "task_plan.md" -Encoding UTF8
+    }
     Write-Host "Created task_plan.md"
 } else {
     Write-Host "task_plan.md already exists, skipping"
@@ -63,7 +81,11 @@ Phase 1
 
 # Create findings.md if it doesn't exist
 if (-not (Test-Path "findings.md")) {
-    @"
+    $AnalyticsFindings = Join-Path $TemplateDir "analytics_findings.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsFindings)) {
+        Copy-Item $AnalyticsFindings "findings.md"
+    } else {
+        @"
 # Findings & Decisions
 
 ## Requirements
@@ -83,6 +105,7 @@ if (-not (Test-Path "findings.md")) {
 ## Resources
 -
 "@ | Out-File -FilePath "findings.md" -Encoding UTF8
+    }
     Write-Host "Created findings.md"
 } else {
     Write-Host "findings.md already exists, skipping"
@@ -90,7 +113,29 @@ if (-not (Test-Path "findings.md")) {
 
 # Create progress.md if it doesn't exist
 if (-not (Test-Path "progress.md")) {
-    @"
+    if ($Template -eq "analytics") {
+        @"
+# Progress Log
+
+## Session: $DATE
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $DATE
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+"@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    } else {
+        @"
 # Progress Log
 
 ## Session: $DATE
@@ -110,6 +155,7 @@ if (-not (Test-Path "progress.md")) {
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    }
     Write-Host "Created progress.md"
 } else {
     Write-Host "progress.md already exists, skipping"

--- a/.continue/skills/planning-with-files/scripts/init-session.sh
+++ b/.continue/skills/planning-with-files/scripts/init-session.sh
@@ -1,17 +1,96 @@
-#!/bin/bash
-# Initialize planning files for a new session
-# Usage: ./init-session.sh [project-name]
+#!/usr/bin/env bash
+# Initialize planning files for a new session.
+#
+# Usage:
+#   ./init-session.sh                              # legacy: root-level task_plan.md, findings.md, progress.md
+#   ./init-session.sh [--template TYPE]            # legacy with template choice
+#   ./init-session.sh "Backend Refactor"           # slug mode: .planning/<date>-backend-refactor/
+#   ./init-session.sh --plan-dir                   # slug mode with auto-generated untitled-<short> name
+#   ./init-session.sh --plan-dir "Quick Spike"     # slug mode, explicit slug
+#
+# Legacy mode (zero positional args, no --plan-dir) preserves v1.x behavior so
+# upgrades stay non-breaking. Slug mode addresses parallel multi-task isolation
+# (issue #148) by writing each plan under .planning/<date>-<slug>/ and pinning
+# .planning/.active_plan so resolve-plan-dir.sh can find it.
 
 set -e
 
-PROJECT_NAME="${1:-project}"
+TEMPLATE="default"
+PROJECT_NAME=""
+USE_PLAN_DIR=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --template|-t)
+            TEMPLATE="$2"
+            shift 2
+            ;;
+        --plan-dir)
+            USE_PLAN_DIR=1
+            shift
+            ;;
+        *)
+            if [ -z "$PROJECT_NAME" ]; then
+                PROJECT_NAME="$1"
+            else
+                PROJECT_NAME="$PROJECT_NAME $1"
+            fi
+            shift
+            ;;
+    esac
+done
+
 DATE=$(date +%Y-%m-%d)
 
-echo "Initializing planning files for: $PROJECT_NAME"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_ROOT="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="$SKILL_ROOT/templates"
 
-# Create task_plan.md if it doesn't exist
-if [ ! -f "task_plan.md" ]; then
-    cat > task_plan.md << 'EOF'
+if [ "$TEMPLATE" != "default" ] && [ "$TEMPLATE" != "analytics" ]; then
+    echo "Unknown template: $TEMPLATE (available: default, analytics). Using default."
+    TEMPLATE="default"
+fi
+
+# Slug mode triggers when a project name was given OR --plan-dir was passed.
+SLUG_MODE=0
+if [ -n "$PROJECT_NAME" ] || [ "$USE_PLAN_DIR" -eq 1 ]; then
+    SLUG_MODE=1
+fi
+
+slugify() {
+    # Lowercase, non-alphanumerics → '-', collapse repeats, trim leading/trailing '-'
+    printf '%s' "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -e 's/[^a-z0-9]/-/g' -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//' \
+        | cut -c1-40
+}
+
+short_uuid() {
+    # Probe each candidate: command -v alone is not enough on Windows because
+    # App Execution Aliases report presence but exit non-zero when run.
+    _py="${PYTHON_BIN:-}"
+    if [ -z "$_py" ]; then
+        for _c in python3 python py; do
+            if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "import uuid" >/dev/null 2>&1; then
+                _py="$_c"
+                break
+            fi
+        done
+    fi
+    if [ -n "$_py" ]; then
+        "$_py" -c "import uuid; print(uuid.uuid4().hex[:8])"
+        return
+    fi
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-' | cut -c1-8
+        return
+    fi
+    # Last-ditch: seconds timestamp as 8 hex chars
+    printf '%08x' "$(date +%s)" | cut -c1-8
+}
+
+write_default_task_plan() {
+    cat > "$1" << 'EOF'
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,14 +135,10 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created task_plan.md"
-else
-    echo "task_plan.md already exists, skipping"
-fi
+}
 
-# Create findings.md if it doesn't exist
-if [ ! -f "findings.md" ]; then
-    cat > findings.md << 'EOF'
+write_default_findings() {
+    cat > "$1" << 'EOF'
 # Findings & Decisions
 
 ## Requirements
@@ -83,21 +158,19 @@ if [ ! -f "findings.md" ]; then
 ## Resources
 -
 EOF
-    echo "Created findings.md"
-else
-    echo "findings.md already exists, skipping"
-fi
+}
 
-# Create progress.md if it doesn't exist
-if [ ! -f "progress.md" ]; then
-    cat > progress.md << EOF
+write_default_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
 # Progress Log
 
-## Session: $DATE
+## Session: $date_value
 
 ### Current Status
 - **Phase:** 1 - Requirements & Discovery
-- **Started:** $DATE
+- **Started:** $date_value
 
 ### Actions Taken
 -
@@ -110,11 +183,102 @@ if [ ! -f "progress.md" ]; then
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created progress.md"
-else
-    echo "progress.md already exists, skipping"
-fi
+}
 
-echo ""
-echo "Planning files initialized!"
-echo "Files: task_plan.md, findings.md, progress.md"
+write_analytics_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
+# Progress Log
+
+## Session: $date_value
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $date_value
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+EOF
+}
+
+create_files_in() {
+    local target_dir="$1"
+    local plan_path="$target_dir/task_plan.md"
+    local findings_path="$target_dir/findings.md"
+    local progress_path="$target_dir/progress.md"
+
+    if [ ! -f "$plan_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_task_plan.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_task_plan.md" "$plan_path"
+        else
+            write_default_task_plan "$plan_path"
+        fi
+        echo "Created $plan_path"
+    else
+        echo "$plan_path already exists, skipping"
+    fi
+
+    if [ ! -f "$findings_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_findings.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_findings.md" "$findings_path"
+        else
+            write_default_findings "$findings_path"
+        fi
+        echo "Created $findings_path"
+    else
+        echo "$findings_path already exists, skipping"
+    fi
+
+    if [ ! -f "$progress_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ]; then
+            write_analytics_progress "$DATE" "$progress_path"
+        else
+            write_default_progress "$DATE" "$progress_path"
+        fi
+        echo "Created $progress_path"
+    else
+        echo "$progress_path already exists, skipping"
+    fi
+}
+
+if [ "$SLUG_MODE" -eq 1 ]; then
+    SLUG="$(slugify "$PROJECT_NAME")"
+    if [ -z "$SLUG" ]; then
+        SLUG="untitled-$(short_uuid)"
+    fi
+    BASE_ID="${DATE}-${SLUG}"
+    PLAN_ID="$BASE_ID"
+    PLAN_ROOT="${PWD}/.planning"
+    counter=2
+    while [ -d "${PLAN_ROOT}/${PLAN_ID}" ]; do
+        PLAN_ID="${BASE_ID}-${counter}"
+        counter=$((counter + 1))
+    done
+    PLAN_DIR="${PLAN_ROOT}/${PLAN_ID}"
+    mkdir -p "$PLAN_DIR"
+
+    echo "Initializing planning files for: ${PROJECT_NAME:-untitled} (template: $TEMPLATE)"
+    echo "PLAN_ID=$PLAN_ID"
+    create_files_in "$PLAN_DIR"
+    printf "%s\n" "$PLAN_ID" > "${PLAN_ROOT}/.active_plan"
+    echo ""
+    echo "Active plan recorded: ${PLAN_ROOT}/.active_plan"
+    echo "Pin this terminal to the plan for parallel sessions:"
+    echo "  export PLAN_ID=$PLAN_ID"
+else
+    PROJECT_NAME="${PROJECT_NAME:-project}"
+    echo "Initializing planning files for: $PROJECT_NAME (template: $TEMPLATE)"
+    create_files_in "$(pwd)"
+    echo ""
+    echo "Planning files initialized!"
+    echo "Files: task_plan.md, findings.md, progress.md"
+fi

--- a/.factory/skills/planning-with-files/scripts/check-complete.sh
+++ b/.factory/skills/planning-with-files/scripts/check-complete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check if all phases in task_plan.md are complete
 # Always exits 0 — uses stdout for status reporting
 # Used by Stop hook to report task completion status

--- a/.factory/skills/planning-with-files/scripts/init-session.ps1
+++ b/.factory/skills/planning-with-files/scripts/init-session.ps1
@@ -1,17 +1,34 @@
 # Initialize planning files for a new session
-# Usage: .\init-session.ps1 [project-name]
+# Usage: .\init-session.ps1 [-Template TYPE] [project-name]
+# Templates: default, analytics
 
 param(
-    [string]$ProjectName = "project"
+    [string]$ProjectName = "project",
+    [string]$Template = "default"
 )
 
 $DATE = Get-Date -Format "yyyy-MM-dd"
 
-Write-Host "Initializing planning files for: $ProjectName"
+# Resolve template directory (skill root is one level up from scripts/)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillRoot = Split-Path -Parent $ScriptDir
+$TemplateDir = Join-Path $SkillRoot "templates"
+
+Write-Host "Initializing planning files for: $ProjectName (template: $Template)"
+
+# Validate template
+if ($Template -ne "default" -and $Template -ne "analytics") {
+    Write-Host "Unknown template: $Template (available: default, analytics). Using default."
+    $Template = "default"
+}
 
 # Create task_plan.md if it doesn't exist
 if (-not (Test-Path "task_plan.md")) {
-    @"
+    $AnalyticsPlan = Join-Path $TemplateDir "analytics_task_plan.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsPlan)) {
+        Copy-Item $AnalyticsPlan "task_plan.md"
+    } else {
+        @"
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,6 +73,7 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "task_plan.md" -Encoding UTF8
+    }
     Write-Host "Created task_plan.md"
 } else {
     Write-Host "task_plan.md already exists, skipping"
@@ -63,7 +81,11 @@ Phase 1
 
 # Create findings.md if it doesn't exist
 if (-not (Test-Path "findings.md")) {
-    @"
+    $AnalyticsFindings = Join-Path $TemplateDir "analytics_findings.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsFindings)) {
+        Copy-Item $AnalyticsFindings "findings.md"
+    } else {
+        @"
 # Findings & Decisions
 
 ## Requirements
@@ -83,6 +105,7 @@ if (-not (Test-Path "findings.md")) {
 ## Resources
 -
 "@ | Out-File -FilePath "findings.md" -Encoding UTF8
+    }
     Write-Host "Created findings.md"
 } else {
     Write-Host "findings.md already exists, skipping"
@@ -90,7 +113,29 @@ if (-not (Test-Path "findings.md")) {
 
 # Create progress.md if it doesn't exist
 if (-not (Test-Path "progress.md")) {
-    @"
+    if ($Template -eq "analytics") {
+        @"
+# Progress Log
+
+## Session: $DATE
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $DATE
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+"@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    } else {
+        @"
 # Progress Log
 
 ## Session: $DATE
@@ -110,6 +155,7 @@ if (-not (Test-Path "progress.md")) {
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    }
     Write-Host "Created progress.md"
 } else {
     Write-Host "progress.md already exists, skipping"

--- a/.factory/skills/planning-with-files/scripts/init-session.sh
+++ b/.factory/skills/planning-with-files/scripts/init-session.sh
@@ -1,17 +1,96 @@
-#!/bin/bash
-# Initialize planning files for a new session
-# Usage: ./init-session.sh [project-name]
+#!/usr/bin/env bash
+# Initialize planning files for a new session.
+#
+# Usage:
+#   ./init-session.sh                              # legacy: root-level task_plan.md, findings.md, progress.md
+#   ./init-session.sh [--template TYPE]            # legacy with template choice
+#   ./init-session.sh "Backend Refactor"           # slug mode: .planning/<date>-backend-refactor/
+#   ./init-session.sh --plan-dir                   # slug mode with auto-generated untitled-<short> name
+#   ./init-session.sh --plan-dir "Quick Spike"     # slug mode, explicit slug
+#
+# Legacy mode (zero positional args, no --plan-dir) preserves v1.x behavior so
+# upgrades stay non-breaking. Slug mode addresses parallel multi-task isolation
+# (issue #148) by writing each plan under .planning/<date>-<slug>/ and pinning
+# .planning/.active_plan so resolve-plan-dir.sh can find it.
 
 set -e
 
-PROJECT_NAME="${1:-project}"
+TEMPLATE="default"
+PROJECT_NAME=""
+USE_PLAN_DIR=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --template|-t)
+            TEMPLATE="$2"
+            shift 2
+            ;;
+        --plan-dir)
+            USE_PLAN_DIR=1
+            shift
+            ;;
+        *)
+            if [ -z "$PROJECT_NAME" ]; then
+                PROJECT_NAME="$1"
+            else
+                PROJECT_NAME="$PROJECT_NAME $1"
+            fi
+            shift
+            ;;
+    esac
+done
+
 DATE=$(date +%Y-%m-%d)
 
-echo "Initializing planning files for: $PROJECT_NAME"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_ROOT="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="$SKILL_ROOT/templates"
 
-# Create task_plan.md if it doesn't exist
-if [ ! -f "task_plan.md" ]; then
-    cat > task_plan.md << 'EOF'
+if [ "$TEMPLATE" != "default" ] && [ "$TEMPLATE" != "analytics" ]; then
+    echo "Unknown template: $TEMPLATE (available: default, analytics). Using default."
+    TEMPLATE="default"
+fi
+
+# Slug mode triggers when a project name was given OR --plan-dir was passed.
+SLUG_MODE=0
+if [ -n "$PROJECT_NAME" ] || [ "$USE_PLAN_DIR" -eq 1 ]; then
+    SLUG_MODE=1
+fi
+
+slugify() {
+    # Lowercase, non-alphanumerics → '-', collapse repeats, trim leading/trailing '-'
+    printf '%s' "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -e 's/[^a-z0-9]/-/g' -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//' \
+        | cut -c1-40
+}
+
+short_uuid() {
+    # Probe each candidate: command -v alone is not enough on Windows because
+    # App Execution Aliases report presence but exit non-zero when run.
+    _py="${PYTHON_BIN:-}"
+    if [ -z "$_py" ]; then
+        for _c in python3 python py; do
+            if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "import uuid" >/dev/null 2>&1; then
+                _py="$_c"
+                break
+            fi
+        done
+    fi
+    if [ -n "$_py" ]; then
+        "$_py" -c "import uuid; print(uuid.uuid4().hex[:8])"
+        return
+    fi
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-' | cut -c1-8
+        return
+    fi
+    # Last-ditch: seconds timestamp as 8 hex chars
+    printf '%08x' "$(date +%s)" | cut -c1-8
+}
+
+write_default_task_plan() {
+    cat > "$1" << 'EOF'
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,14 +135,10 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created task_plan.md"
-else
-    echo "task_plan.md already exists, skipping"
-fi
+}
 
-# Create findings.md if it doesn't exist
-if [ ! -f "findings.md" ]; then
-    cat > findings.md << 'EOF'
+write_default_findings() {
+    cat > "$1" << 'EOF'
 # Findings & Decisions
 
 ## Requirements
@@ -83,21 +158,19 @@ if [ ! -f "findings.md" ]; then
 ## Resources
 -
 EOF
-    echo "Created findings.md"
-else
-    echo "findings.md already exists, skipping"
-fi
+}
 
-# Create progress.md if it doesn't exist
-if [ ! -f "progress.md" ]; then
-    cat > progress.md << EOF
+write_default_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
 # Progress Log
 
-## Session: $DATE
+## Session: $date_value
 
 ### Current Status
 - **Phase:** 1 - Requirements & Discovery
-- **Started:** $DATE
+- **Started:** $date_value
 
 ### Actions Taken
 -
@@ -110,11 +183,102 @@ if [ ! -f "progress.md" ]; then
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created progress.md"
-else
-    echo "progress.md already exists, skipping"
-fi
+}
 
-echo ""
-echo "Planning files initialized!"
-echo "Files: task_plan.md, findings.md, progress.md"
+write_analytics_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
+# Progress Log
+
+## Session: $date_value
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $date_value
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+EOF
+}
+
+create_files_in() {
+    local target_dir="$1"
+    local plan_path="$target_dir/task_plan.md"
+    local findings_path="$target_dir/findings.md"
+    local progress_path="$target_dir/progress.md"
+
+    if [ ! -f "$plan_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_task_plan.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_task_plan.md" "$plan_path"
+        else
+            write_default_task_plan "$plan_path"
+        fi
+        echo "Created $plan_path"
+    else
+        echo "$plan_path already exists, skipping"
+    fi
+
+    if [ ! -f "$findings_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_findings.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_findings.md" "$findings_path"
+        else
+            write_default_findings "$findings_path"
+        fi
+        echo "Created $findings_path"
+    else
+        echo "$findings_path already exists, skipping"
+    fi
+
+    if [ ! -f "$progress_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ]; then
+            write_analytics_progress "$DATE" "$progress_path"
+        else
+            write_default_progress "$DATE" "$progress_path"
+        fi
+        echo "Created $progress_path"
+    else
+        echo "$progress_path already exists, skipping"
+    fi
+}
+
+if [ "$SLUG_MODE" -eq 1 ]; then
+    SLUG="$(slugify "$PROJECT_NAME")"
+    if [ -z "$SLUG" ]; then
+        SLUG="untitled-$(short_uuid)"
+    fi
+    BASE_ID="${DATE}-${SLUG}"
+    PLAN_ID="$BASE_ID"
+    PLAN_ROOT="${PWD}/.planning"
+    counter=2
+    while [ -d "${PLAN_ROOT}/${PLAN_ID}" ]; do
+        PLAN_ID="${BASE_ID}-${counter}"
+        counter=$((counter + 1))
+    done
+    PLAN_DIR="${PLAN_ROOT}/${PLAN_ID}"
+    mkdir -p "$PLAN_DIR"
+
+    echo "Initializing planning files for: ${PROJECT_NAME:-untitled} (template: $TEMPLATE)"
+    echo "PLAN_ID=$PLAN_ID"
+    create_files_in "$PLAN_DIR"
+    printf "%s\n" "$PLAN_ID" > "${PLAN_ROOT}/.active_plan"
+    echo ""
+    echo "Active plan recorded: ${PLAN_ROOT}/.active_plan"
+    echo "Pin this terminal to the plan for parallel sessions:"
+    echo "  export PLAN_ID=$PLAN_ID"
+else
+    PROJECT_NAME="${PROJECT_NAME:-project}"
+    echo "Initializing planning files for: $PROJECT_NAME (template: $TEMPLATE)"
+    create_files_in "$(pwd)"
+    echo ""
+    echo "Planning files initialized!"
+    echo "Files: task_plan.md, findings.md, progress.md"
+fi

--- a/.gemini/skills/planning-with-files/scripts/check-complete.sh
+++ b/.gemini/skills/planning-with-files/scripts/check-complete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check if all phases in task_plan.md are complete
 # Always exits 0 — uses stdout for status reporting
 # Used by Stop hook to report task completion status

--- a/.gemini/skills/planning-with-files/scripts/init-session.ps1
+++ b/.gemini/skills/planning-with-files/scripts/init-session.ps1
@@ -1,17 +1,34 @@
 # Initialize planning files for a new session
-# Usage: .\init-session.ps1 [project-name]
+# Usage: .\init-session.ps1 [-Template TYPE] [project-name]
+# Templates: default, analytics
 
 param(
-    [string]$ProjectName = "project"
+    [string]$ProjectName = "project",
+    [string]$Template = "default"
 )
 
 $DATE = Get-Date -Format "yyyy-MM-dd"
 
-Write-Host "Initializing planning files for: $ProjectName"
+# Resolve template directory (skill root is one level up from scripts/)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillRoot = Split-Path -Parent $ScriptDir
+$TemplateDir = Join-Path $SkillRoot "templates"
+
+Write-Host "Initializing planning files for: $ProjectName (template: $Template)"
+
+# Validate template
+if ($Template -ne "default" -and $Template -ne "analytics") {
+    Write-Host "Unknown template: $Template (available: default, analytics). Using default."
+    $Template = "default"
+}
 
 # Create task_plan.md if it doesn't exist
 if (-not (Test-Path "task_plan.md")) {
-    @"
+    $AnalyticsPlan = Join-Path $TemplateDir "analytics_task_plan.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsPlan)) {
+        Copy-Item $AnalyticsPlan "task_plan.md"
+    } else {
+        @"
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,6 +73,7 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "task_plan.md" -Encoding UTF8
+    }
     Write-Host "Created task_plan.md"
 } else {
     Write-Host "task_plan.md already exists, skipping"
@@ -63,7 +81,11 @@ Phase 1
 
 # Create findings.md if it doesn't exist
 if (-not (Test-Path "findings.md")) {
-    @"
+    $AnalyticsFindings = Join-Path $TemplateDir "analytics_findings.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsFindings)) {
+        Copy-Item $AnalyticsFindings "findings.md"
+    } else {
+        @"
 # Findings & Decisions
 
 ## Requirements
@@ -83,6 +105,7 @@ if (-not (Test-Path "findings.md")) {
 ## Resources
 -
 "@ | Out-File -FilePath "findings.md" -Encoding UTF8
+    }
     Write-Host "Created findings.md"
 } else {
     Write-Host "findings.md already exists, skipping"
@@ -90,7 +113,29 @@ if (-not (Test-Path "findings.md")) {
 
 # Create progress.md if it doesn't exist
 if (-not (Test-Path "progress.md")) {
-    @"
+    if ($Template -eq "analytics") {
+        @"
+# Progress Log
+
+## Session: $DATE
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $DATE
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+"@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    } else {
+        @"
 # Progress Log
 
 ## Session: $DATE
@@ -110,6 +155,7 @@ if (-not (Test-Path "progress.md")) {
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    }
     Write-Host "Created progress.md"
 } else {
     Write-Host "progress.md already exists, skipping"

--- a/.gemini/skills/planning-with-files/scripts/init-session.sh
+++ b/.gemini/skills/planning-with-files/scripts/init-session.sh
@@ -1,17 +1,96 @@
-#!/bin/bash
-# Initialize planning files for a new session
-# Usage: ./init-session.sh [project-name]
+#!/usr/bin/env bash
+# Initialize planning files for a new session.
+#
+# Usage:
+#   ./init-session.sh                              # legacy: root-level task_plan.md, findings.md, progress.md
+#   ./init-session.sh [--template TYPE]            # legacy with template choice
+#   ./init-session.sh "Backend Refactor"           # slug mode: .planning/<date>-backend-refactor/
+#   ./init-session.sh --plan-dir                   # slug mode with auto-generated untitled-<short> name
+#   ./init-session.sh --plan-dir "Quick Spike"     # slug mode, explicit slug
+#
+# Legacy mode (zero positional args, no --plan-dir) preserves v1.x behavior so
+# upgrades stay non-breaking. Slug mode addresses parallel multi-task isolation
+# (issue #148) by writing each plan under .planning/<date>-<slug>/ and pinning
+# .planning/.active_plan so resolve-plan-dir.sh can find it.
 
 set -e
 
-PROJECT_NAME="${1:-project}"
+TEMPLATE="default"
+PROJECT_NAME=""
+USE_PLAN_DIR=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --template|-t)
+            TEMPLATE="$2"
+            shift 2
+            ;;
+        --plan-dir)
+            USE_PLAN_DIR=1
+            shift
+            ;;
+        *)
+            if [ -z "$PROJECT_NAME" ]; then
+                PROJECT_NAME="$1"
+            else
+                PROJECT_NAME="$PROJECT_NAME $1"
+            fi
+            shift
+            ;;
+    esac
+done
+
 DATE=$(date +%Y-%m-%d)
 
-echo "Initializing planning files for: $PROJECT_NAME"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_ROOT="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="$SKILL_ROOT/templates"
 
-# Create task_plan.md if it doesn't exist
-if [ ! -f "task_plan.md" ]; then
-    cat > task_plan.md << 'EOF'
+if [ "$TEMPLATE" != "default" ] && [ "$TEMPLATE" != "analytics" ]; then
+    echo "Unknown template: $TEMPLATE (available: default, analytics). Using default."
+    TEMPLATE="default"
+fi
+
+# Slug mode triggers when a project name was given OR --plan-dir was passed.
+SLUG_MODE=0
+if [ -n "$PROJECT_NAME" ] || [ "$USE_PLAN_DIR" -eq 1 ]; then
+    SLUG_MODE=1
+fi
+
+slugify() {
+    # Lowercase, non-alphanumerics → '-', collapse repeats, trim leading/trailing '-'
+    printf '%s' "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -e 's/[^a-z0-9]/-/g' -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//' \
+        | cut -c1-40
+}
+
+short_uuid() {
+    # Probe each candidate: command -v alone is not enough on Windows because
+    # App Execution Aliases report presence but exit non-zero when run.
+    _py="${PYTHON_BIN:-}"
+    if [ -z "$_py" ]; then
+        for _c in python3 python py; do
+            if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "import uuid" >/dev/null 2>&1; then
+                _py="$_c"
+                break
+            fi
+        done
+    fi
+    if [ -n "$_py" ]; then
+        "$_py" -c "import uuid; print(uuid.uuid4().hex[:8])"
+        return
+    fi
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-' | cut -c1-8
+        return
+    fi
+    # Last-ditch: seconds timestamp as 8 hex chars
+    printf '%08x' "$(date +%s)" | cut -c1-8
+}
+
+write_default_task_plan() {
+    cat > "$1" << 'EOF'
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,14 +135,10 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created task_plan.md"
-else
-    echo "task_plan.md already exists, skipping"
-fi
+}
 
-# Create findings.md if it doesn't exist
-if [ ! -f "findings.md" ]; then
-    cat > findings.md << 'EOF'
+write_default_findings() {
+    cat > "$1" << 'EOF'
 # Findings & Decisions
 
 ## Requirements
@@ -83,21 +158,19 @@ if [ ! -f "findings.md" ]; then
 ## Resources
 -
 EOF
-    echo "Created findings.md"
-else
-    echo "findings.md already exists, skipping"
-fi
+}
 
-# Create progress.md if it doesn't exist
-if [ ! -f "progress.md" ]; then
-    cat > progress.md << EOF
+write_default_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
 # Progress Log
 
-## Session: $DATE
+## Session: $date_value
 
 ### Current Status
 - **Phase:** 1 - Requirements & Discovery
-- **Started:** $DATE
+- **Started:** $date_value
 
 ### Actions Taken
 -
@@ -110,11 +183,102 @@ if [ ! -f "progress.md" ]; then
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created progress.md"
-else
-    echo "progress.md already exists, skipping"
-fi
+}
 
-echo ""
-echo "Planning files initialized!"
-echo "Files: task_plan.md, findings.md, progress.md"
+write_analytics_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
+# Progress Log
+
+## Session: $date_value
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $date_value
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+EOF
+}
+
+create_files_in() {
+    local target_dir="$1"
+    local plan_path="$target_dir/task_plan.md"
+    local findings_path="$target_dir/findings.md"
+    local progress_path="$target_dir/progress.md"
+
+    if [ ! -f "$plan_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_task_plan.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_task_plan.md" "$plan_path"
+        else
+            write_default_task_plan "$plan_path"
+        fi
+        echo "Created $plan_path"
+    else
+        echo "$plan_path already exists, skipping"
+    fi
+
+    if [ ! -f "$findings_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_findings.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_findings.md" "$findings_path"
+        else
+            write_default_findings "$findings_path"
+        fi
+        echo "Created $findings_path"
+    else
+        echo "$findings_path already exists, skipping"
+    fi
+
+    if [ ! -f "$progress_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ]; then
+            write_analytics_progress "$DATE" "$progress_path"
+        else
+            write_default_progress "$DATE" "$progress_path"
+        fi
+        echo "Created $progress_path"
+    else
+        echo "$progress_path already exists, skipping"
+    fi
+}
+
+if [ "$SLUG_MODE" -eq 1 ]; then
+    SLUG="$(slugify "$PROJECT_NAME")"
+    if [ -z "$SLUG" ]; then
+        SLUG="untitled-$(short_uuid)"
+    fi
+    BASE_ID="${DATE}-${SLUG}"
+    PLAN_ID="$BASE_ID"
+    PLAN_ROOT="${PWD}/.planning"
+    counter=2
+    while [ -d "${PLAN_ROOT}/${PLAN_ID}" ]; do
+        PLAN_ID="${BASE_ID}-${counter}"
+        counter=$((counter + 1))
+    done
+    PLAN_DIR="${PLAN_ROOT}/${PLAN_ID}"
+    mkdir -p "$PLAN_DIR"
+
+    echo "Initializing planning files for: ${PROJECT_NAME:-untitled} (template: $TEMPLATE)"
+    echo "PLAN_ID=$PLAN_ID"
+    create_files_in "$PLAN_DIR"
+    printf "%s\n" "$PLAN_ID" > "${PLAN_ROOT}/.active_plan"
+    echo ""
+    echo "Active plan recorded: ${PLAN_ROOT}/.active_plan"
+    echo "Pin this terminal to the plan for parallel sessions:"
+    echo "  export PLAN_ID=$PLAN_ID"
+else
+    PROJECT_NAME="${PROJECT_NAME:-project}"
+    echo "Initializing planning files for: $PROJECT_NAME (template: $TEMPLATE)"
+    create_files_in "$(pwd)"
+    echo ""
+    echo "Planning files initialized!"
+    echo "Files: task_plan.md, findings.md, progress.md"
+fi

--- a/.pi/skills/planning-with-files/scripts/check-complete.sh
+++ b/.pi/skills/planning-with-files/scripts/check-complete.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Check if all phases in task_plan.md are complete
 # Always exits 0 — uses stdout for status reporting
 # Used by Stop hook to report task completion status

--- a/.pi/skills/planning-with-files/scripts/init-session.ps1
+++ b/.pi/skills/planning-with-files/scripts/init-session.ps1
@@ -1,17 +1,34 @@
 # Initialize planning files for a new session
-# Usage: .\init-session.ps1 [project-name]
+# Usage: .\init-session.ps1 [-Template TYPE] [project-name]
+# Templates: default, analytics
 
 param(
-    [string]$ProjectName = "project"
+    [string]$ProjectName = "project",
+    [string]$Template = "default"
 )
 
 $DATE = Get-Date -Format "yyyy-MM-dd"
 
-Write-Host "Initializing planning files for: $ProjectName"
+# Resolve template directory (skill root is one level up from scripts/)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillRoot = Split-Path -Parent $ScriptDir
+$TemplateDir = Join-Path $SkillRoot "templates"
+
+Write-Host "Initializing planning files for: $ProjectName (template: $Template)"
+
+# Validate template
+if ($Template -ne "default" -and $Template -ne "analytics") {
+    Write-Host "Unknown template: $Template (available: default, analytics). Using default."
+    $Template = "default"
+}
 
 # Create task_plan.md if it doesn't exist
 if (-not (Test-Path "task_plan.md")) {
-    @"
+    $AnalyticsPlan = Join-Path $TemplateDir "analytics_task_plan.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsPlan)) {
+        Copy-Item $AnalyticsPlan "task_plan.md"
+    } else {
+        @"
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,6 +73,7 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "task_plan.md" -Encoding UTF8
+    }
     Write-Host "Created task_plan.md"
 } else {
     Write-Host "task_plan.md already exists, skipping"
@@ -63,7 +81,11 @@ Phase 1
 
 # Create findings.md if it doesn't exist
 if (-not (Test-Path "findings.md")) {
-    @"
+    $AnalyticsFindings = Join-Path $TemplateDir "analytics_findings.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsFindings)) {
+        Copy-Item $AnalyticsFindings "findings.md"
+    } else {
+        @"
 # Findings & Decisions
 
 ## Requirements
@@ -83,6 +105,7 @@ if (-not (Test-Path "findings.md")) {
 ## Resources
 -
 "@ | Out-File -FilePath "findings.md" -Encoding UTF8
+    }
     Write-Host "Created findings.md"
 } else {
     Write-Host "findings.md already exists, skipping"
@@ -90,7 +113,29 @@ if (-not (Test-Path "findings.md")) {
 
 # Create progress.md if it doesn't exist
 if (-not (Test-Path "progress.md")) {
-    @"
+    if ($Template -eq "analytics") {
+        @"
+# Progress Log
+
+## Session: $DATE
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $DATE
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+"@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    } else {
+        @"
 # Progress Log
 
 ## Session: $DATE
@@ -110,6 +155,7 @@ if (-not (Test-Path "progress.md")) {
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    }
     Write-Host "Created progress.md"
 } else {
     Write-Host "progress.md already exists, skipping"

--- a/.pi/skills/planning-with-files/scripts/init-session.sh
+++ b/.pi/skills/planning-with-files/scripts/init-session.sh
@@ -1,17 +1,96 @@
-#!/bin/bash
-# Initialize planning files for a new session
-# Usage: ./init-session.sh [project-name]
+#!/usr/bin/env bash
+# Initialize planning files for a new session.
+#
+# Usage:
+#   ./init-session.sh                              # legacy: root-level task_plan.md, findings.md, progress.md
+#   ./init-session.sh [--template TYPE]            # legacy with template choice
+#   ./init-session.sh "Backend Refactor"           # slug mode: .planning/<date>-backend-refactor/
+#   ./init-session.sh --plan-dir                   # slug mode with auto-generated untitled-<short> name
+#   ./init-session.sh --plan-dir "Quick Spike"     # slug mode, explicit slug
+#
+# Legacy mode (zero positional args, no --plan-dir) preserves v1.x behavior so
+# upgrades stay non-breaking. Slug mode addresses parallel multi-task isolation
+# (issue #148) by writing each plan under .planning/<date>-<slug>/ and pinning
+# .planning/.active_plan so resolve-plan-dir.sh can find it.
 
 set -e
 
-PROJECT_NAME="${1:-project}"
+TEMPLATE="default"
+PROJECT_NAME=""
+USE_PLAN_DIR=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --template|-t)
+            TEMPLATE="$2"
+            shift 2
+            ;;
+        --plan-dir)
+            USE_PLAN_DIR=1
+            shift
+            ;;
+        *)
+            if [ -z "$PROJECT_NAME" ]; then
+                PROJECT_NAME="$1"
+            else
+                PROJECT_NAME="$PROJECT_NAME $1"
+            fi
+            shift
+            ;;
+    esac
+done
+
 DATE=$(date +%Y-%m-%d)
 
-echo "Initializing planning files for: $PROJECT_NAME"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_ROOT="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="$SKILL_ROOT/templates"
 
-# Create task_plan.md if it doesn't exist
-if [ ! -f "task_plan.md" ]; then
-    cat > task_plan.md << 'EOF'
+if [ "$TEMPLATE" != "default" ] && [ "$TEMPLATE" != "analytics" ]; then
+    echo "Unknown template: $TEMPLATE (available: default, analytics). Using default."
+    TEMPLATE="default"
+fi
+
+# Slug mode triggers when a project name was given OR --plan-dir was passed.
+SLUG_MODE=0
+if [ -n "$PROJECT_NAME" ] || [ "$USE_PLAN_DIR" -eq 1 ]; then
+    SLUG_MODE=1
+fi
+
+slugify() {
+    # Lowercase, non-alphanumerics → '-', collapse repeats, trim leading/trailing '-'
+    printf '%s' "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -e 's/[^a-z0-9]/-/g' -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//' \
+        | cut -c1-40
+}
+
+short_uuid() {
+    # Probe each candidate: command -v alone is not enough on Windows because
+    # App Execution Aliases report presence but exit non-zero when run.
+    _py="${PYTHON_BIN:-}"
+    if [ -z "$_py" ]; then
+        for _c in python3 python py; do
+            if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "import uuid" >/dev/null 2>&1; then
+                _py="$_c"
+                break
+            fi
+        done
+    fi
+    if [ -n "$_py" ]; then
+        "$_py" -c "import uuid; print(uuid.uuid4().hex[:8])"
+        return
+    fi
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-' | cut -c1-8
+        return
+    fi
+    # Last-ditch: seconds timestamp as 8 hex chars
+    printf '%08x' "$(date +%s)" | cut -c1-8
+}
+
+write_default_task_plan() {
+    cat > "$1" << 'EOF'
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,14 +135,10 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created task_plan.md"
-else
-    echo "task_plan.md already exists, skipping"
-fi
+}
 
-# Create findings.md if it doesn't exist
-if [ ! -f "findings.md" ]; then
-    cat > findings.md << 'EOF'
+write_default_findings() {
+    cat > "$1" << 'EOF'
 # Findings & Decisions
 
 ## Requirements
@@ -83,21 +158,19 @@ if [ ! -f "findings.md" ]; then
 ## Resources
 -
 EOF
-    echo "Created findings.md"
-else
-    echo "findings.md already exists, skipping"
-fi
+}
 
-# Create progress.md if it doesn't exist
-if [ ! -f "progress.md" ]; then
-    cat > progress.md << EOF
+write_default_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
 # Progress Log
 
-## Session: $DATE
+## Session: $date_value
 
 ### Current Status
 - **Phase:** 1 - Requirements & Discovery
-- **Started:** $DATE
+- **Started:** $date_value
 
 ### Actions Taken
 -
@@ -110,11 +183,102 @@ if [ ! -f "progress.md" ]; then
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created progress.md"
-else
-    echo "progress.md already exists, skipping"
-fi
+}
 
-echo ""
-echo "Planning files initialized!"
-echo "Files: task_plan.md, findings.md, progress.md"
+write_analytics_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
+# Progress Log
+
+## Session: $date_value
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $date_value
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+EOF
+}
+
+create_files_in() {
+    local target_dir="$1"
+    local plan_path="$target_dir/task_plan.md"
+    local findings_path="$target_dir/findings.md"
+    local progress_path="$target_dir/progress.md"
+
+    if [ ! -f "$plan_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_task_plan.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_task_plan.md" "$plan_path"
+        else
+            write_default_task_plan "$plan_path"
+        fi
+        echo "Created $plan_path"
+    else
+        echo "$plan_path already exists, skipping"
+    fi
+
+    if [ ! -f "$findings_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_findings.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_findings.md" "$findings_path"
+        else
+            write_default_findings "$findings_path"
+        fi
+        echo "Created $findings_path"
+    else
+        echo "$findings_path already exists, skipping"
+    fi
+
+    if [ ! -f "$progress_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ]; then
+            write_analytics_progress "$DATE" "$progress_path"
+        else
+            write_default_progress "$DATE" "$progress_path"
+        fi
+        echo "Created $progress_path"
+    else
+        echo "$progress_path already exists, skipping"
+    fi
+}
+
+if [ "$SLUG_MODE" -eq 1 ]; then
+    SLUG="$(slugify "$PROJECT_NAME")"
+    if [ -z "$SLUG" ]; then
+        SLUG="untitled-$(short_uuid)"
+    fi
+    BASE_ID="${DATE}-${SLUG}"
+    PLAN_ID="$BASE_ID"
+    PLAN_ROOT="${PWD}/.planning"
+    counter=2
+    while [ -d "${PLAN_ROOT}/${PLAN_ID}" ]; do
+        PLAN_ID="${BASE_ID}-${counter}"
+        counter=$((counter + 1))
+    done
+    PLAN_DIR="${PLAN_ROOT}/${PLAN_ID}"
+    mkdir -p "$PLAN_DIR"
+
+    echo "Initializing planning files for: ${PROJECT_NAME:-untitled} (template: $TEMPLATE)"
+    echo "PLAN_ID=$PLAN_ID"
+    create_files_in "$PLAN_DIR"
+    printf "%s\n" "$PLAN_ID" > "${PLAN_ROOT}/.active_plan"
+    echo ""
+    echo "Active plan recorded: ${PLAN_ROOT}/.active_plan"
+    echo "Pin this terminal to the plan for parallel sessions:"
+    echo "  export PLAN_ID=$PLAN_ID"
+else
+    PROJECT_NAME="${PROJECT_NAME:-project}"
+    echo "Initializing planning files for: $PROJECT_NAME (template: $TEMPLATE)"
+    create_files_in "$(pwd)"
+    echo ""
+    echo "Planning files initialized!"
+    echo "Files: task_plan.md, findings.md, progress.md"
+fi

--- a/skills/planning-with-files/scripts/init-session.ps1
+++ b/skills/planning-with-files/scripts/init-session.ps1
@@ -1,17 +1,34 @@
 # Initialize planning files for a new session
-# Usage: .\init-session.ps1 [project-name]
+# Usage: .\init-session.ps1 [-Template TYPE] [project-name]
+# Templates: default, analytics
 
 param(
-    [string]$ProjectName = "project"
+    [string]$ProjectName = "project",
+    [string]$Template = "default"
 )
 
 $DATE = Get-Date -Format "yyyy-MM-dd"
 
-Write-Host "Initializing planning files for: $ProjectName"
+# Resolve template directory (skill root is one level up from scripts/)
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SkillRoot = Split-Path -Parent $ScriptDir
+$TemplateDir = Join-Path $SkillRoot "templates"
+
+Write-Host "Initializing planning files for: $ProjectName (template: $Template)"
+
+# Validate template
+if ($Template -ne "default" -and $Template -ne "analytics") {
+    Write-Host "Unknown template: $Template (available: default, analytics). Using default."
+    $Template = "default"
+}
 
 # Create task_plan.md if it doesn't exist
 if (-not (Test-Path "task_plan.md")) {
-    @"
+    $AnalyticsPlan = Join-Path $TemplateDir "analytics_task_plan.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsPlan)) {
+        Copy-Item $AnalyticsPlan "task_plan.md"
+    } else {
+        @"
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,6 +73,7 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "task_plan.md" -Encoding UTF8
+    }
     Write-Host "Created task_plan.md"
 } else {
     Write-Host "task_plan.md already exists, skipping"
@@ -63,7 +81,11 @@ Phase 1
 
 # Create findings.md if it doesn't exist
 if (-not (Test-Path "findings.md")) {
-    @"
+    $AnalyticsFindings = Join-Path $TemplateDir "analytics_findings.md"
+    if ($Template -eq "analytics" -and (Test-Path $AnalyticsFindings)) {
+        Copy-Item $AnalyticsFindings "findings.md"
+    } else {
+        @"
 # Findings & Decisions
 
 ## Requirements
@@ -83,6 +105,7 @@ if (-not (Test-Path "findings.md")) {
 ## Resources
 -
 "@ | Out-File -FilePath "findings.md" -Encoding UTF8
+    }
     Write-Host "Created findings.md"
 } else {
     Write-Host "findings.md already exists, skipping"
@@ -90,7 +113,29 @@ if (-not (Test-Path "findings.md")) {
 
 # Create progress.md if it doesn't exist
 if (-not (Test-Path "progress.md")) {
-    @"
+    if ($Template -eq "analytics") {
+        @"
+# Progress Log
+
+## Session: $DATE
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $DATE
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+"@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    } else {
+        @"
 # Progress Log
 
 ## Session: $DATE
@@ -110,6 +155,7 @@ if (-not (Test-Path "progress.md")) {
 | Error | Resolution |
 |-------|------------|
 "@ | Out-File -FilePath "progress.md" -Encoding UTF8
+    }
     Write-Host "Created progress.md"
 } else {
     Write-Host "progress.md already exists, skipping"

--- a/skills/planning-with-files/scripts/init-session.sh
+++ b/skills/planning-with-files/scripts/init-session.sh
@@ -1,17 +1,96 @@
 #!/usr/bin/env bash
-# Initialize planning files for a new session
-# Usage: ./init-session.sh [project-name]
+# Initialize planning files for a new session.
+#
+# Usage:
+#   ./init-session.sh                              # legacy: root-level task_plan.md, findings.md, progress.md
+#   ./init-session.sh [--template TYPE]            # legacy with template choice
+#   ./init-session.sh "Backend Refactor"           # slug mode: .planning/<date>-backend-refactor/
+#   ./init-session.sh --plan-dir                   # slug mode with auto-generated untitled-<short> name
+#   ./init-session.sh --plan-dir "Quick Spike"     # slug mode, explicit slug
+#
+# Legacy mode (zero positional args, no --plan-dir) preserves v1.x behavior so
+# upgrades stay non-breaking. Slug mode addresses parallel multi-task isolation
+# (issue #148) by writing each plan under .planning/<date>-<slug>/ and pinning
+# .planning/.active_plan so resolve-plan-dir.sh can find it.
 
 set -e
 
-PROJECT_NAME="${1:-project}"
+TEMPLATE="default"
+PROJECT_NAME=""
+USE_PLAN_DIR=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --template|-t)
+            TEMPLATE="$2"
+            shift 2
+            ;;
+        --plan-dir)
+            USE_PLAN_DIR=1
+            shift
+            ;;
+        *)
+            if [ -z "$PROJECT_NAME" ]; then
+                PROJECT_NAME="$1"
+            else
+                PROJECT_NAME="$PROJECT_NAME $1"
+            fi
+            shift
+            ;;
+    esac
+done
+
 DATE=$(date +%Y-%m-%d)
 
-echo "Initializing planning files for: $PROJECT_NAME"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SKILL_ROOT="$(dirname "$SCRIPT_DIR")"
+TEMPLATE_DIR="$SKILL_ROOT/templates"
 
-# Create task_plan.md if it doesn't exist
-if [ ! -f "task_plan.md" ]; then
-    cat > task_plan.md << 'EOF'
+if [ "$TEMPLATE" != "default" ] && [ "$TEMPLATE" != "analytics" ]; then
+    echo "Unknown template: $TEMPLATE (available: default, analytics). Using default."
+    TEMPLATE="default"
+fi
+
+# Slug mode triggers when a project name was given OR --plan-dir was passed.
+SLUG_MODE=0
+if [ -n "$PROJECT_NAME" ] || [ "$USE_PLAN_DIR" -eq 1 ]; then
+    SLUG_MODE=1
+fi
+
+slugify() {
+    # Lowercase, non-alphanumerics → '-', collapse repeats, trim leading/trailing '-'
+    printf '%s' "$1" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -e 's/[^a-z0-9]/-/g' -e 's/-\{2,\}/-/g' -e 's/^-//' -e 's/-$//' \
+        | cut -c1-40
+}
+
+short_uuid() {
+    # Probe each candidate: command -v alone is not enough on Windows because
+    # App Execution Aliases report presence but exit non-zero when run.
+    _py="${PYTHON_BIN:-}"
+    if [ -z "$_py" ]; then
+        for _c in python3 python py; do
+            if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "import uuid" >/dev/null 2>&1; then
+                _py="$_c"
+                break
+            fi
+        done
+    fi
+    if [ -n "$_py" ]; then
+        "$_py" -c "import uuid; print(uuid.uuid4().hex[:8])"
+        return
+    fi
+    if command -v uuidgen >/dev/null 2>&1; then
+        uuidgen | tr '[:upper:]' '[:lower:]' | tr -d '-' | cut -c1-8
+        return
+    fi
+    # Last-ditch: seconds timestamp as 8 hex chars
+    printf '%08x' "$(date +%s)" | cut -c1-8
+}
+
+write_default_task_plan() {
+    cat > "$1" << 'EOF'
 # Task Plan: [Brief Description]
 
 ## Goal
@@ -56,14 +135,10 @@ Phase 1
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created task_plan.md"
-else
-    echo "task_plan.md already exists, skipping"
-fi
+}
 
-# Create findings.md if it doesn't exist
-if [ ! -f "findings.md" ]; then
-    cat > findings.md << 'EOF'
+write_default_findings() {
+    cat > "$1" << 'EOF'
 # Findings & Decisions
 
 ## Requirements
@@ -83,21 +158,19 @@ if [ ! -f "findings.md" ]; then
 ## Resources
 -
 EOF
-    echo "Created findings.md"
-else
-    echo "findings.md already exists, skipping"
-fi
+}
 
-# Create progress.md if it doesn't exist
-if [ ! -f "progress.md" ]; then
-    cat > progress.md << EOF
+write_default_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
 # Progress Log
 
-## Session: $DATE
+## Session: $date_value
 
 ### Current Status
 - **Phase:** 1 - Requirements & Discovery
-- **Started:** $DATE
+- **Started:** $date_value
 
 ### Actions Taken
 -
@@ -110,11 +183,102 @@ if [ ! -f "progress.md" ]; then
 | Error | Resolution |
 |-------|------------|
 EOF
-    echo "Created progress.md"
-else
-    echo "progress.md already exists, skipping"
-fi
+}
 
-echo ""
-echo "Planning files initialized!"
-echo "Files: task_plan.md, findings.md, progress.md"
+write_analytics_progress() {
+    local date_value="$1"
+    local target="$2"
+    cat > "$target" << EOF
+# Progress Log
+
+## Session: $date_value
+
+### Current Status
+- **Phase:** 1 - Data Discovery
+- **Started:** $date_value
+
+### Actions Taken
+-
+
+### Query Log
+| Query | Result Summary | Interpretation |
+|-------|---------------|----------------|
+
+### Errors
+| Error | Resolution |
+|-------|------------|
+EOF
+}
+
+create_files_in() {
+    local target_dir="$1"
+    local plan_path="$target_dir/task_plan.md"
+    local findings_path="$target_dir/findings.md"
+    local progress_path="$target_dir/progress.md"
+
+    if [ ! -f "$plan_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_task_plan.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_task_plan.md" "$plan_path"
+        else
+            write_default_task_plan "$plan_path"
+        fi
+        echo "Created $plan_path"
+    else
+        echo "$plan_path already exists, skipping"
+    fi
+
+    if [ ! -f "$findings_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ] && [ -f "$TEMPLATE_DIR/analytics_findings.md" ]; then
+            cp "$TEMPLATE_DIR/analytics_findings.md" "$findings_path"
+        else
+            write_default_findings "$findings_path"
+        fi
+        echo "Created $findings_path"
+    else
+        echo "$findings_path already exists, skipping"
+    fi
+
+    if [ ! -f "$progress_path" ]; then
+        if [ "$TEMPLATE" = "analytics" ]; then
+            write_analytics_progress "$DATE" "$progress_path"
+        else
+            write_default_progress "$DATE" "$progress_path"
+        fi
+        echo "Created $progress_path"
+    else
+        echo "$progress_path already exists, skipping"
+    fi
+}
+
+if [ "$SLUG_MODE" -eq 1 ]; then
+    SLUG="$(slugify "$PROJECT_NAME")"
+    if [ -z "$SLUG" ]; then
+        SLUG="untitled-$(short_uuid)"
+    fi
+    BASE_ID="${DATE}-${SLUG}"
+    PLAN_ID="$BASE_ID"
+    PLAN_ROOT="${PWD}/.planning"
+    counter=2
+    while [ -d "${PLAN_ROOT}/${PLAN_ID}" ]; do
+        PLAN_ID="${BASE_ID}-${counter}"
+        counter=$((counter + 1))
+    done
+    PLAN_DIR="${PLAN_ROOT}/${PLAN_ID}"
+    mkdir -p "$PLAN_DIR"
+
+    echo "Initializing planning files for: ${PROJECT_NAME:-untitled} (template: $TEMPLATE)"
+    echo "PLAN_ID=$PLAN_ID"
+    create_files_in "$PLAN_DIR"
+    printf "%s\n" "$PLAN_ID" > "${PLAN_ROOT}/.active_plan"
+    echo ""
+    echo "Active plan recorded: ${PLAN_ROOT}/.active_plan"
+    echo "Pin this terminal to the plan for parallel sessions:"
+    echo "  export PLAN_ID=$PLAN_ID"
+else
+    PROJECT_NAME="${PROJECT_NAME:-project}"
+    echo "Initializing planning files for: $PROJECT_NAME (template: $TEMPLATE)"
+    create_files_in "$(pwd)"
+    echo ""
+    echo "Planning files initialized!"
+    echo "Files: task_plan.md, findings.md, progress.md"
+fi

--- a/tests/test_canonical_script_sync.py
+++ b/tests/test_canonical_script_sync.py
@@ -1,0 +1,80 @@
+"""Regression test: keep top-level scripts/ in sync with canonical skills/.../scripts/.
+
+Background — the repo ships two parallel copies of the helper scripts:
+
+  * `scripts/...`                              — top-level (used by tests, CI, dev)
+  * `skills/planning-with-files/scripts/...`   — canonical for the shipped skill;
+                                                 sync-ide-folders.py copies this one
+                                                 into all `.<ide>/skills/.../scripts/`.
+
+Past PRs (analytics template in v2.29.0, slug-mode in v2.36.0) edited only the
+top-level copy and forgot the canonical, so users installing the skill via any IDE
+folder ended up with the previous-version script. This test catches that class of
+drift up front.
+
+It also exercises sync-ide-folders.py --verify so the IDE-folder mirrors stay
+honest after every commit.
+"""
+from __future__ import annotations
+
+import filecmp
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TOP_SCRIPTS = REPO_ROOT / "scripts"
+SKILL_SCRIPTS = REPO_ROOT / "skills" / "planning-with-files" / "scripts"
+
+# Files that exist in both locations and must stay byte-identical.
+# session-catchup.py is intentionally NOT in this list — the canonical copy carries
+# Codex-specific catchup logic that does not (yet) live at the top level.
+SHARED_SCRIPTS = (
+    "init-session.sh",
+    "init-session.ps1",
+    "check-complete.sh",
+    "check-complete.ps1",
+)
+
+
+class CanonicalScriptSyncTests(unittest.TestCase):
+    def test_shared_scripts_match_canonical_copy(self) -> None:
+        mismatches = []
+        for name in SHARED_SCRIPTS:
+            top = TOP_SCRIPTS / name
+            skill = SKILL_SCRIPTS / name
+            self.assertTrue(top.is_file(), f"missing top-level script: {top}")
+            self.assertTrue(skill.is_file(), f"missing canonical skill script: {skill}")
+            if not filecmp.cmp(top, skill, shallow=False):
+                mismatches.append(name)
+
+        self.assertFalse(
+            mismatches,
+            "Drift detected between scripts/ and skills/planning-with-files/scripts/. "
+            f"Out-of-sync files: {mismatches}. "
+            "Update both copies in the same PR (see CHANGELOG v2.36.0 for the original "
+            "miss). After updating the canonical skill copy, run "
+            "`python scripts/sync-ide-folders.py` to refresh IDE folders.",
+        )
+
+    def test_sync_ide_folders_verify_clean(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts" / "sync-ide-folders.py"), "--verify"],
+            cwd=str(REPO_ROOT),
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(
+            0,
+            result.returncode,
+            "sync-ide-folders.py --verify reported drift. "
+            "Run `python scripts/sync-ide-folders.py` from the repo root to fix.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The v2.36.0 release notes promise:

> **init-session.sh** now accepts a task name and creates a dated, readable plan directory under `.planning/YYYY-MM-DD-<slug>/`. (#148, @shawnli1874)

That rewrite landed in `scripts/init-session.sh` (top-level) but never reached the canonical `skills/planning-with-files/scripts/init-session.{sh,ps1}` that ships in the plugin. Users installing the skill via any of the nine IDE folders (`.codex/`, `.gemini/`, `.pi/`, `.codebuddy/`, `.continue/`, `.factory/`, …) get the v2.0.0 legacy-only init-session and **silently miss** the parallel-plan isolation feature called out as the v2.36.0 headline.

The same gap quietly existed for v2.29.0: the `--template analytics` flag from #115 (@mvanhorn) was added only to the top-level scripts and never to the canonical skill copy.

```
$ grep -c 'SLUG_MODE\|--plan-dir\|slugify' scripts/init-session.sh
12
$ grep -c 'SLUG_MODE\|--plan-dir\|slugify' skills/planning-with-files/scripts/init-session.sh
0
```

## Fix

- **Sync canonical to match top-level**: byte-for-byte copy of `scripts/init-session.{sh,ps1}` into `skills/planning-with-files/scripts/`. Brings slug mode, `--plan-dir`, `--template analytics`, and the v2.36.0 Windows-aware `short_uuid` probing into the shipped skill.
- **Refresh IDE mirrors via the existing tool**: `python scripts/sync-ide-folders.py` propagates the canonical to `.codebuddy/`, `.codex/`, `.continue/`, `.factory/`, `.gemini/`, `.pi/`. Same pass picks up the v2.35.1 `/usr/bin/env bash` shebang on `check-complete.sh` in those IDE folders — Emin017's #145 landed against the canonical only and the IDE mirrors had drifted.
- **Add a regression test** so this can't silently happen again:
  - `tests/test_canonical_script_sync.py::test_shared_scripts_match_canonical_copy` — `init-session.{sh,ps1}` and `check-complete.{sh,ps1}` must be byte-identical between `scripts/` and `skills/planning-with-files/scripts/`. `session-catchup.py` is **intentionally excluded** from this check (the canonical copy carries Codex-specific catchup logic that doesn't live at the top level).
  - `tests/test_canonical_script_sync.py::test_sync_ide_folders_verify_clean` — invokes `python scripts/sync-ide-folders.py --verify` and asserts exit 0, so any future commit that updates the canonical without re-running the sync trips the test in CI.

## Scope discipline

- The five language variants (`planning-with-files-{ar,de,es,zh,zht}`) have separate copies that are not auto-synced and also lack slug-mode. Out of scope here — they're not in `IDE_MANIFESTS` and would deserve a translator-aware follow-up. Happy to send a second PR if you want them lined up.
- `session-catchup.py` is intentionally not part of the parity assertion. The canonical version has Codex catchup features (orjson, MIN_SESSION_BYTES, current-thread preference) that the top-level version does not. If you want them merged that's its own conversation; this PR doesn't touch the question.

## Local gates

- `python3.11 -m unittest discover tests` → **70 pass / 1 pre-existing fail**. The single fail is `test_installed_plugin_resolves_repo_assets_for_completion_check` in `test_hermes_adapter.py`, an unrelated macOS `/private/var/...` tempdir-symlink path comparison that already fails on upstream master at f7e8919 (zero changes from this branch). New tests pass: 70 = 68 baseline + 2 new.
- `python3.11 -m unittest tests/test_init_session_slug.py` → 6/6 pass. The pre-existing slug-mode behavior tests still target the top-level script and still pass; the parity assertion in the new test ensures the canonical copy now exhibits the same behavior.
- **End-to-end smoke** of the canonical skill copy:

```
$ bash skills/planning-with-files/scripts/init-session.sh "Smoke Test Run"
Initializing planning files for: Smoke Test Run (template: default)
PLAN_ID=2026-05-02-smoke-test-run
Created /tmp/smoke/.planning/2026-05-02-smoke-test-run/task_plan.md
Created /tmp/smoke/.planning/2026-05-02-smoke-test-run/findings.md
Created /tmp/smoke/.planning/2026-05-02-smoke-test-run/progress.md
Active plan recorded: /tmp/smoke/.planning/.active_plan
```

Legacy mode (zero args) in a separate tmp dir keeps root-level files and doesn't create `.planning/` — backward-compat preserved.

## Why this PR is +1727/-257 across 20 files

The line counts make this look bigger than it is. The actual logic change is:

1. One script (`init-session.sh`) and one PowerShell script (`init-session.ps1`) updated in the canonical location.
2. `sync-ide-folders.py` then mirrors the canonical into 6 IDE folders × 3 files each = 18 mechanical copies.
3. One new 75-line test file.

The non-test diff is essentially the same ~280-line file replicated across IDE folders that the existing sync tool generates.

## Generated with Claude Code

Per the project's recent merge precedent for `🤖 Generated with` trailers (PRs #126, #145, etc.), full disclosure: implementation drafted with Claude Code and verified against the local test suite + smoke-tested before push. All assertions in this PR body were checked locally.
