### PR TITLE
fix: resolve init-session POSIX shell loop

### DIFF
--- a/.codebuddy/skills/planning-with-files/scripts/init-session.sh
+++ b/.codebuddy/skills/planning-with-files/scripts/init-session.sh
@@ -19,7 +19,7 @@ TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case "$1" in
         --template|-t)
             TEMPLATE="$2"

--- a/.codex/skills/planning-with-files/scripts/init-session.sh
+++ b/.codex/skills/planning-with-files/scripts/init-session.sh
@@ -19,7 +19,7 @@ TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case "$1" in
         --template|-t)
             TEMPLATE="$2"

--- a/.continue/skills/planning-with-files/scripts/init-session.sh
+++ b/.continue/skills/planning-with-files/scripts/init-session.sh
@@ -19,7 +19,7 @@ TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case "$1" in
         --template|-t)
             TEMPLATE="$2"

--- a/.factory/skills/planning-with-files/scripts/init-session.sh
+++ b/.factory/skills/planning-with-files/scripts/init-session.sh
@@ -19,7 +19,7 @@ TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case "$1" in
         --template|-t)
             TEMPLATE="$2"

--- a/.gemini/skills/planning-with-files/scripts/init-session.sh
+++ b/.gemini/skills/planning-with-files/scripts/init-session.sh
@@ -19,7 +19,7 @@ TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case "$1" in
         --template|-t)
             TEMPLATE="$2"

--- a/.pi/skills/planning-with-files/scripts/init-session.sh
+++ b/.pi/skills/planning-with-files/scripts/init-session.sh
@@ -19,7 +19,7 @@ TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case "$1" in
         --template|-t)
             TEMPLATE="$2"

--- a/scripts/init-session.sh
+++ b/scripts/init-session.sh
@@ -19,7 +19,7 @@ TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case "$1" in
         --template|-t)
             TEMPLATE="$2"

--- a/skills/planning-with-files/scripts/init-session.sh
+++ b/skills/planning-with-files/scripts/init-session.sh
@@ -19,7 +19,7 @@ TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
     case "$1" in
         --template|-t)
             TEMPLATE="$2"


### PR DESCRIPTION
## Summary
- replace the bash-only `[[ ... ]]` loop condition with POSIX `[ ... ]` in the synced init-session.sh copies
- keep the canonical script and distributed copies in parity
- restore slug-mode test compatibility when the test invokes the script through `/bin/sh` on Ubuntu/dash

## Tests
- `git diff --check upstream/master..fix/init-session-posix`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/pwf-review-venv/bin/python -m pytest tests/test_init_session_slug.py tests/test_canonical_script_sync.py tests/test_script_permissions.py -q` -> 10 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/pwf-review-venv/bin/python -m pytest tests/ -q` -> 132 passed

Note: local ignored ClawHub upload fixture metadata was aligned to 2.41.0 for the parity test; it is not part of this branch.