### PR TITLE
fix: make Codex stop hook non-blocking for incomplete plans

### DIFF
--- a/.codex/hooks/stop.py
+++ b/.codex/hooks/stop.py
@@ -18,15 +18,7 @@ def main() -> None:
     if not isinstance(message, str) or not message:
         return
 
-    if "ALL PHASES COMPLETE" in message:
-        adapter.emit_json({"systemMessage": message})
-        return
-
-    if bool(payload.get("stop_hook_active")):
-        adapter.emit_json({"systemMessage": message})
-        return
-
-    adapter.emit_json({"decision": "block", "reason": message})
+    adapter.emit_json({"systemMessage": message})
 
 
 if __name__ == "__main__":

--- a/.codex/hooks/stop.sh
+++ b/.codex/hooks/stop.sh
@@ -30,5 +30,5 @@ if [ "$COMPLETE" -eq "$TOTAL" ] && [ "$TOTAL" -gt 0 ]; then
     exit 0
 fi
 
-echo "{\"followup_message\": \"[planning-with-files] Task incomplete ($COMPLETE/$TOTAL phases done). Update progress.md, then read task_plan.md and continue working on the remaining phases.\"}"
+echo "{\"followup_message\": \"[planning-with-files] Task in progress ($COMPLETE/$TOTAL phases complete). If ending this turn, make sure progress.md is up to date.\"}"
 exit 0

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -147,7 +147,7 @@ class CodexHooksTests(unittest.TestCase):
         payload = json.loads(result.stdout)
         self.assertIn("progress.md", payload["systemMessage"])
 
-    def test_stop_adapter_blocks_once_then_allows_reentry(self) -> None:
+    def test_stop_adapter_reports_incomplete_plan_without_blocking(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             root.joinpath("task_plan.md").write_text(
@@ -180,9 +180,12 @@ class CodexHooksTests(unittest.TestCase):
         first_payload = json.loads(first.stdout)
         second_payload = json.loads(second.stdout)
 
-        self.assertEqual("block", first_payload["decision"])
-        self.assertIn("Task incomplete", first_payload["reason"])
-        self.assertIn("Task incomplete", second_payload["systemMessage"])
+        self.assertNotIn("decision", first_payload)
+        self.assertNotIn("reason", first_payload)
+        self.assertIn("Task in progress", first_payload["systemMessage"])
+        self.assertIn("progress.md is up to date", first_payload["systemMessage"])
+        self.assertNotIn("continue working", first_payload["systemMessage"])
+        self.assertIn("Task in progress", second_payload["systemMessage"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make the Codex Stop hook report incomplete plans as a non-blocking `systemMessage`
- remove the imperative "continue working on the remaining phases" wording from the stop message
- update the Codex hook test to assert that incomplete plans do not emit `decision: block`

## Motivation

Closes #178.

An incomplete plan is a normal planning state. Blocking Stop for `COMPLETE < TOTAL` can make Codex continue into another phase without an explicit user request. This keeps the handoff reminder, but avoids turning a status check into a continuation command.

## Verification

```bash
python3 -m unittest tests.test_codex_hooks tests.test_codex_session_isolation
```

Passed locally.

I also ran the full unittest discovery. It reached unrelated existing environment/repo issues: missing local `pytest`, macOS `/private/var` temp path normalization, and missing `clawhub-upload/SKILL.md`. The targeted Codex hook tests above pass.
