### PR TITLE
fix: add Codex PreCompact hook

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -56,6 +56,18 @@
         ]
       }
     ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh .codex/hooks/pre-compact.sh 2>/dev/null || sh \"$HOME/.codex/hooks/pre-compact.sh\" 2>/dev/null || true",
+            "statusMessage": "Preparing planning context before compact"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.codex/hooks/pre-compact.sh
+++ b/.codex/hooks/pre-compact.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# planning-with-files: PreCompact hook for Codex
+# Reminds the agent to flush progress before context compaction.
+
+HOOK_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)"
+PLAN_DIR="$(sh "${HOOK_DIR}/resolve-plan-dir.sh" 2>/dev/null)"
+PLAN_FILE="${PLAN_DIR:+${PLAN_DIR}/}task_plan.md"
+
+if [ ! -f "$PLAN_FILE" ]; then
+    exit 0
+fi
+
+if [ -n "$PLAN_DIR" ]; then
+    ATTESTATION_FILE="${PLAN_DIR}/.attestation"
+else
+    ATTESTATION_FILE=".plan-attestation"
+fi
+
+echo "[planning-with-files] PreCompact: context compaction is about to occur."
+echo "Before compaction completes: ensure progress.md captures recent actions and task_plan.md status reflects current phase."
+echo "task_plan.md, findings.md, progress.md remain on disk and will be re-read after compaction."
+
+if [ -f "$ATTESTATION_FILE" ]; then
+    ATTEST="$(tr -d '\r\n[:space:]' < "$ATTESTATION_FILE" 2>/dev/null)"
+    if [ -n "$ATTEST" ]; then
+        echo "Plan-SHA256 at compaction: $ATTEST"
+    fi
+fi
+
+exit 0

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -100,7 +100,7 @@ Codex reads hooks from:
 1. `.codex/hooks.json` in your project root
 2. `~/.codex/hooks.json` for your global install
 
-This integration includes all five Codex lifecycle hooks:
+This integration includes the Codex lifecycle hooks used by the adapter:
 
 | Hook | What It Does |
 |------|--------------|
@@ -108,6 +108,7 @@ This integration includes all five Codex lifecycle hooks:
 | **UserPromptSubmit** | Re-injects plan and recent progress on every user message |
 | **PreToolUse** | Re-reads the first 30 lines of `task_plan.md` before Bash |
 | **PostToolUse** | Reminds the agent to update `progress.md` after Bash activity |
+| **PreCompact** | Reminds the agent to flush `progress.md` and `task_plan.md` before compaction |
 | **Stop** | Blocks once when phases are incomplete, then falls back to a follow-up reminder |
 
 ### The Three Files

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -46,6 +46,7 @@ class CodexHooksTests(unittest.TestCase):
                 "PreToolUse",
                 "PermissionRequest",
                 "PostToolUse",
+                "PreCompact",
                 "Stop",
             },
             set(payload["hooks"]),
@@ -146,6 +147,27 @@ class CodexHooksTests(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
         payload = json.loads(result.stdout)
         self.assertIn("progress.md", payload["systemMessage"])
+
+    def test_pre_compact_emits_flush_reminder(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            root.joinpath("task_plan.md").write_text("# Task Plan\n", encoding="utf-8")
+            root.joinpath(".plan-attestation").write_text("abc123\n", encoding="utf-8")
+
+            result = self.run_shell_hook("pre-compact.sh", root)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("[planning-with-files] PreCompact", result.stdout)
+        self.assertIn("progress.md", result.stdout)
+        self.assertIn("Plan-SHA256", result.stdout)
+
+    def test_pre_compact_silent_without_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            result = self.run_shell_hook("pre-compact.sh", root)
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("", result.stdout.strip())
 
     def test_stop_adapter_blocks_once_then_allows_reentry(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## What

This PR registers the Codex `PreCompact` hook in `.codex/hooks.json` and adds a small `.codex/hooks/pre-compact.sh` adapter. The hook reminds the agent to flush `progress.md` and `task_plan.md` before Codex compacts the conversation.

It also updates the Codex documentation table and adds tests for the new hook behavior.

## Why

The canonical `skills/planning-with-files/SKILL.md` already declares a `PreCompact` hook, and the repository has a test that validates that declaration. However, the Codex adapter configuration did not register `PreCompact` in `.codex/hooks.json`.

That means a Codex global or workspace install can have the planning files and the normal lifecycle hooks, but still miss the pre-compaction reminder that asks the agent to write the current state back to disk before context compaction.

This closes that adapter gap by making the Codex hook configuration match the lifecycle support already declared by the skill.

## Testing

Passed:

```bash
python3 -m json.tool .codex/hooks.json >/dev/null
bash -n .codex/hooks/*.sh
uv run --with pytest --python /Users/shuaige/.local/bin/python3.11 python -m pytest tests/test_codex_hooks.py tests/test_precompact_hook.py -q
# 15 passed
```

Full suite note:

```bash
uv run --with pytest --python /Users/shuaige/.local/bin/python3.11 python -m pytest tests/ -q
# 132 passed, 2 failed
```

The same two full-suite failures also reproduce on a clean `upstream/master` worktree on this macOS machine:

- `tests/test_hermes_adapter.py::HermesAdapterTests::test_installed_plugin_resolves_repo_assets_for_completion_check` compares `/var/...` with `/private/var/...`.
- `tests/test_skill_md_version_parity.py::SkillMdVersionParityTests::test_all_parity_skill_md_share_canonical_version` expects `clawhub-upload/SKILL.md`, which is missing from the checked-out upstream tree.

So the targeted Codex hook tests pass, while the two full-suite failures appear unrelated to this PR.

## Limitations

This only changes the Codex adapter. It does not change Stop-hook behavior or any non-Codex adapter.
