### PR TITLE
fix: sync legacy skills/ SKILL.md to IDE-specific paths

### DIFF
--- a/skills/planning-with-files/SKILL.md
+++ b/skills/planning-with-files/SKILL.md
@@ -43,7 +43,14 @@ Work like Manus: Use persistent markdown files as your "working memory on disk."
 **Before starting work**, check for unsynced context from a previous session:
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/scripts/session-catchup.py "$(pwd)"
+# Claude Code users
+python3 ~/.claude/skills/planning-with-files/scripts/session-catchup.py "$(pwd)"
+
+# Codex users
+python3 ~/.codex/skills/planning-with-files/scripts/session-catchup.py "$(pwd)"
+
+# Cursor users
+python3 ~/.cursor/skills/planning-with-files/scripts/session-catchup.py "$(pwd)"
 ```
 
 If catchup report shows unsynced context:
@@ -54,12 +61,16 @@ If catchup report shows unsynced context:
 
 ## Important: Where Files Go
 
-- **Templates** are in `${CLAUDE_PLUGIN_ROOT}/templates/`
-- **Your planning files** go in **your project directory**
+**Templates location (based on your IDE):**
+- Claude Code: `~/.claude/skills/planning-with-files/templates/`
+- Codex: `~/.codex/skills/planning-with-files/templates/`
+- Cursor: `~/.cursor/skills/planning-with-files/templates/`
+
+**Your planning files** go in **your project directory**
 
 | Location | What Goes There |
 |----------|-----------------|
-| Skill directory (`${CLAUDE_PLUGIN_ROOT}/`) | Templates, scripts, reference docs |
+| Skill directory (`~/.claude/skills/planning-with-files/` or `~/.codex/skills/planning-with-files/`) | Templates, scripts, reference docs |
 | Your project directory | `task_plan.md`, `findings.md`, `progress.md` |
 
 ## Quick Start


### PR DESCRIPTION
## What

The legacy `skills/planning-with-files/SKILL.md` still referenced `${CLAUDE_PLUGIN_ROOT}` in its prose body, while the plugin copy `planning-with-files/SKILL.md` was updated to explicit per-IDE paths in 7de9247. This syncs the legacy copy so the two are identical.

## Why

Non-Claude-Code installs read the legacy `skills/` copy (Codex `~/.codex/...`, Cursor `~/.cursor/...`). With the old `${CLAUDE_PLUGIN_ROOT}` references, those users got paths that don't resolve in their IDE. Two spots were stale:

- the session-catchup command block
- the "Important: Where Files Go" section

## Changes

- `skills/planning-with-files/SKILL.md`: session-catchup block now lists Claude Code / Codex / Cursor variants; "Where Files Go" uses IDE-specific template paths — now byte-identical to the plugin copy.

Hooks frontmatter still uses `${CLAUDE_PLUGIN_ROOT}` (correct — that resolves in the plugin runtime); only the human-readable prose paths changed. No functional/runtime change for Claude Code users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)