### PR TITLE
docs: check canonical Codex hooks feature flag

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -82,12 +82,12 @@ If you already have a `[features]` section, add `hooks = true` under it instead 
 
 ```bash
 codex --version
-codex features list | rg '^codex_hooks\s'
+codex features list | rg '^(hooks|codex_hooks)\s'
 ls -la ~/.codex/skills/planning-with-files/SKILL.md
 ls -la ~/.codex/hooks.json ~/.codex/hooks/
 ```
 
-If `codex_hooks` does not appear in `codex features list`, upgrade Codex before troubleshooting the skill.
+If neither `hooks` nor the deprecated alias `codex_hooks` appears in `codex features list`, upgrade Codex before troubleshooting the skill.
 
 ---
 


### PR DESCRIPTION
## Summary
- Update the Codex verification command to check the canonical `hooks` feature flag as well as the deprecated `codex_hooks` alias.
- Align the follow-up troubleshooting sentence with the current `hooks = true` guidance earlier in the document.

## Testing
- `git diff --check`
- `python -m pytest tests/test_codex_hooks.py tests/test_precompact_hook.py tests/test_codex_session_isolation.py -q` - 23 passed
- `python -m pytest tests/ -q` - 183 passed, 1 failed: `tests/test_hermes_adapter.py::HermesAdapterTests::test_installed_plugin_resolves_repo_assets_for_completion_check` compares `/var/...` with `/private/var/...` on macOS temp paths; this is outside the docs-only Codex change.
