### PR TITLE
fix: session-catchup command fails when PLUGIN_ROOT is unset (fixes #185)

### DIFF
--- a/.codebuddy/skills/planning-with-files/SKILL.md
+++ b/.codebuddy/skills/planning-with-files/SKILL.md
@@ -41,8 +41,9 @@ Work like Manus: Use persistent markdown files as your "working memory on disk."
 **Before starting work**, check for unsynced context from a previous session:
 
 ```bash
-# Linux/macOS (auto-detects python3 or python)
-$(command -v python3 || command -v python) ${CODEBUDDY_PLUGIN_ROOT}/scripts/session-catchup.py "$(pwd)"
+# Linux/macOS — auto-detects skill directory (plugin env or default install path)
+SKILL_DIR="${CODEBUDDY_PLUGIN_ROOT:-$HOME/.codebuddy/skills/planning-with-files}"
+$(command -v python3 || command -v python) "${SKILL_DIR}/scripts/session-catchup.py" "$(pwd)"
 ```
 
 ```powershell

--- a/skills/planning-with-files-ar/SKILL.md
+++ b/skills/planning-with-files-ar/SKILL.md
@@ -44,7 +44,8 @@ metadata:
 
 ```bash
 # Linux/macOS
-$(command -v python3 || command -v python) ${CLAUDE_PLUGIN_ROOT}/scripts/session-catchup.py "$(pwd)"
+SKILL_DIR="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files-ar}"
+$(command -v python3 || command -v python) "${SKILL_DIR}/scripts/session-catchup.py" "$(pwd)"
 ```
 
 ```powershell

--- a/skills/planning-with-files-de/SKILL.md
+++ b/skills/planning-with-files-de/SKILL.md
@@ -44,7 +44,8 @@ Arbeite wie Manus: Verwende persistente Markdown-Dateien als deinen „Festplatt
 
 ```bash
 # Linux/macOS
-$(command -v python3 || command -v python) ${CLAUDE_PLUGIN_ROOT}/scripts/session-catchup.py "$(pwd)"
+SKILL_DIR="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files-de}"
+$(command -v python3 || command -v python) "${SKILL_DIR}/scripts/session-catchup.py" "$(pwd)"
 ```
 
 ```powershell

--- a/skills/planning-with-files-es/SKILL.md
+++ b/skills/planning-with-files-es/SKILL.md
@@ -44,7 +44,8 @@ Trabaja como Manus: usa archivos Markdown persistentes como tu «memoria de trab
 
 ```bash
 # Linux/macOS
-$(command -v python3 || command -v python) ${CLAUDE_PLUGIN_ROOT}/scripts/session-catchup.py "$(pwd)"
+SKILL_DIR="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files-es}"
+$(command -v python3 || command -v python) "${SKILL_DIR}/scripts/session-catchup.py" "$(pwd)"
 ```
 
 ```powershell

--- a/skills/planning-with-files-zh/SKILL.md
+++ b/skills/planning-with-files-zh/SKILL.md
@@ -46,7 +46,8 @@ metadata:
 
 ```bash
 # Linux/macOS
-$(command -v python3 || command -v python) ${CLAUDE_PLUGIN_ROOT}/scripts/session-catchup.py "$(pwd)"
+SKILL_DIR="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files-zh}"
+$(command -v python3 || command -v python) "${SKILL_DIR}/scripts/session-catchup.py" "$(pwd)"
 ```
 
 ```powershell

--- a/skills/planning-with-files-zht/SKILL.md
+++ b/skills/planning-with-files-zht/SKILL.md
@@ -46,7 +46,8 @@ metadata:
 
 ```bash
 # Linux/macOS
-$(command -v python3 || command -v python) ${CLAUDE_PLUGIN_ROOT}/scripts/session-catchup.py "$(pwd)"
+SKILL_DIR="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files-zht}"
+$(command -v python3 || command -v python) "${SKILL_DIR}/scripts/session-catchup.py" "$(pwd)"
 ```
 
 ```powershell

--- a/skills/planning-with-files/SKILL.md
+++ b/skills/planning-with-files/SKILL.md
@@ -43,8 +43,9 @@ Work like Manus: Use persistent markdown files as your "working memory on disk."
 2. Then check for unsynced context from a previous session:
 
 ```bash
-# Linux/macOS
-$(command -v python3 || command -v python) ${CLAUDE_PLUGIN_ROOT}/scripts/session-catchup.py "$(pwd)"
+# Linux/macOS — auto-detects skill directory (plugin env or default install path)
+SKILL_DIR="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files}"
+$(command -v python3 || command -v python) "${SKILL_DIR}/scripts/session-catchup.py" "$(pwd)"
 ```
 
 ```powershell


### PR DESCRIPTION
## Problem

Fixes #185 — the session-catchup command documented in SKILL.md fails when run outside the plugin runtime because `${CLAUDE_PLUGIN_ROOT}` is only set by the plugin loader.

In an interactive shell, the command collapses to an invalid absolute path.

## Fix

Use shell parameter expansion `${VAR:-fallback}` so the command works in both contexts:

```bash
SKILL_DIR="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/skills/planning-with-files}"
$(command -v python3 || command -v python) "${SKILL_DIR}/scripts/session-catchup.py" "$(pwd)"
```

- **Plugin users**: `CLAUDE_PLUGIN_ROOT` is set → takes priority, no behavior change
- **Non-plugin users**: falls back to `~/.claude/skills/planning-with-files/` → command works

## Files changed (7 files, +16/-9 lines)

| File | Change |
|------|--------|
| `skills/planning-with-files/SKILL.md` | Canonical — `${CLAUDE_PLUGIN_ROOT}` → fallback |
| `.codebuddy/skills/planning-with-files/SKILL.md` | CodeBuddy — `${CODEBUDDY_PLUGIN_ROOT}` → fallback |
| `skills/planning-with-files-{ar,de,es,zh,zht}/SKILL.md` | 5 language variants — same fix |

Tool-specific variants (`.codex`, `.cursor`, `.kiro`, `.hermes`, etc.) already use hardcoded paths and were not changed.

## Constraints respected

- ✅ `CLAUDE_PLUGIN_ROOT` still works for plugin users (takes priority when set)
- ✅ Windows PowerShell catchup block unchanged
- ✅ Language variants kept in sync
- ✅ No desync with tool-specific variants