### PR TITLE
Add Autohand Code setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ When your context fills up and you run `/clear`, this skill **automatically reco
 </details>
 
 <details>
-<summary><strong>🛠️ Supported IDEs (17+ Platforms)</strong></summary>
+<summary><strong>🛠️ Supported IDEs (18+ Platforms)</strong></summary>
 
 #### Enhanced Support (hooks + lifecycle automation)
 
@@ -177,6 +177,7 @@ These IDEs implement the [Agent Skills](https://agentskills.io) open specificati
 | Continue | [Continue Setup](docs/continue.md) | `.continue/skills/` + [.prompt files](https://docs.continue.dev/customize/deep-dives/prompts) |
 | Pi Agent | [Pi Agent Setup](docs/pi-agent.md) | `.pi/skills/` ([npm package](https://www.npmjs.com/package/@mariozechner/pi-coding-agent)) |
 | OpenClaw | [OpenClaw Setup](docs/openclaw.md) | `.openclaw/skills/` ([docs](https://docs.openclaw.ai/tools/skills)) |
+| Autohand Code | [Autohand Code Setup](docs/autohand.md) | `~/.autohand/skills/` or `.autohand/skills/` |
 | Antigravity | [Antigravity Setup](docs/antigravity.md) | `.agent/skills/` ([docs](https://codelabs.developers.google.com/getting-started-with-antigravity-skills)) |
 | Kilocode | [Kilocode Setup](docs/kilocode.md) | `.kilocode/skills/` ([docs](https://kilo.ai/docs/agent-behavior/skills)) |
 | AdaL CLI (Sylph AI) | [AdaL Setup](docs/adal.md) | `.adal/skills/` ([docs](https://docs.sylph.ai/features/plugins-and-skills)) |
@@ -250,7 +251,7 @@ npx skills add OthmanAdi/planning-with-files --skill planning-with-files-zht -g
 
 </details>
 
-Works with Claude Code, Cursor, Codex, Gemini CLI, and 40+ agents supporting the [Agent Skills](https://agentskills.io) spec.
+Works with Claude Code, Cursor, Codex, Gemini CLI, Autohand Code, and 40+ agents supporting the [Agent Skills](https://agentskills.io) spec.
 
 <details>
 <summary><strong>🔧 Claude Code Plugin (Advanced Features)</strong></summary>

--- a/docs/autohand.md
+++ b/docs/autohand.md
@@ -1,0 +1,95 @@
+# Autohand Code Setup
+
+How to use planning-with-files with [Autohand Code](https://github.com/autohandai/code-cli/).
+
+---
+
+## What This Integration Adds
+
+- Standard Agent Skill loading through Autohand Code skill discovery.
+- Full templates, scripts, and reference documentation from the canonical skill.
+- User-level or project-level installs.
+
+Autohand Code discovers skills from multiple locations, including:
+
+1. **User-level skills:** `~/.autohand/skills/`
+2. **Project-level skills:** `<project>/.autohand/skills/`
+3. **Shared Agent Skills:** `~/.agents/skills/`
+
+---
+
+## Installation (standard Agent Skills)
+
+Install with the shared Agent Skills installer:
+
+```bash
+npx skills add OthmanAdi/planning-with-files --skill planning-with-files -g
+```
+
+This installs into the shared Agent Skills convention that Autohand Code can scan.
+
+---
+
+## Installation (Autohand-native user scope)
+
+Install just for your user account:
+
+```bash
+git clone https://github.com/OthmanAdi/planning-with-files.git /tmp/planning-with-files
+mkdir -p ~/.autohand/skills
+cp -r /tmp/planning-with-files/skills/planning-with-files ~/.autohand/skills/
+rm -rf /tmp/planning-with-files
+```
+
+---
+
+## Installation (Autohand-native project scope)
+
+Commit the skill to a project so the whole team gets the same planning workflow:
+
+```bash
+git clone https://github.com/OthmanAdi/planning-with-files.git /tmp/planning-with-files
+mkdir -p .autohand/skills
+cp -r /tmp/planning-with-files/skills/planning-with-files .autohand/skills/
+git add .autohand/skills/planning-with-files
+git commit -m "Add planning-with-files skill for Autohand Code"
+rm -rf /tmp/planning-with-files
+```
+
+---
+
+## Autohand Catalog Skills
+
+Autohand Code can browse its community catalog with:
+
+```bash
+autohand --skill-install
+```
+
+Project-scoped catalog installs use:
+
+```bash
+autohand --skill-install <skill-name> --project
+```
+
+For this repository, use `npx skills add` or the direct clone paths above unless the skill appears in the Autohand catalog.
+
+---
+
+## Usage
+
+Start Autohand Code in your project. For complex tasks, the skill guides the agent to create and maintain:
+
+- `task_plan.md` — phases, progress, and decisions
+- `findings.md` — research and discoveries
+- `progress.md` — session log and test results
+
+The planning files live in your project root, not inside the skill directory.
+
+---
+
+## Notes
+
+- This is standard Agent Skills support. Claude Code plugin commands and Claude-specific hooks are not installed by this path.
+- The underlying planning files are tool-agnostic and work across Claude Code, Cursor, Codex, Autohand Code, and other agents.
+- If you use both shared `~/.agents/skills/` and Autohand-native directories, avoid installing duplicate copies of the same skill.


### PR DESCRIPTION
Hi, thanks for maintaining planning-with-files and all of the host-specific setup docs.

This adds Autohand Code to the standard Agent Skills support table and adds a small `docs/autohand.md` guide. I kept the scope intentionally narrow:

- documents user-level `~/.autohand/skills/` installs
- documents project-level `.autohand/skills/` installs
- keeps `npx skills add` as the shared standard install path
- notes that this is standard Agent Skills support, not Claude Code plugin commands or Claude-specific hooks

I did not touch the parity-locked SKILL.md variants or release sync scripts, because this is only a docs path for Autohand-native discovery.

Tests were not run because this is documentation-only; `git diff --check` passes locally.