### PR TITLE
fix: make containment and path-sanitize tests portable to CI runners

### DIFF
--- a/tests/test_containment.py
+++ b/tests/test_containment.py
@@ -32,6 +32,29 @@ def have_sh() -> bool:
     return shutil.which("sh") is not None
 
 
+def host_realpath(sh_path: str) -> str:
+    """Canonicalize a path emitted by an sh script for host-side comparison.
+
+    Under Git Bash on Windows the resolver prints POSIX-style paths, and the
+    user temp directory is mounted at /tmp, so os.path.realpath on the raw
+    string would resolve against a nonexistent C:\\tmp and the containment
+    assertion would fail even though the resolved dir is contained. Map the
+    path back to its Windows form with cygpath first, then canonicalize.
+    """
+    if os.name == "nt" and sh_path.startswith("/"):
+        cygpath = shutil.which("cygpath")
+        if cygpath:
+            mapped = subprocess.run(
+                [cygpath, "-w", sh_path],
+                text=True,
+                capture_output=True,
+                check=False,
+            ).stdout.strip()
+            if mapped:
+                sh_path = mapped
+    return os.path.realpath(sh_path)
+
+
 def can_make_escaping_symlink() -> bool:
     """True only if we can create a dir symlink that realpath sees escaping root.
 
@@ -123,10 +146,12 @@ class ContainmentTests(unittest.TestCase):
                 resolved.endswith("escape"),
                 f"escaping symlink dir must be rejected, got {resolved!r}",
             )
-            # And the resolved path (if any) must stay under the root.
+            # And the resolved path (if any) must stay under the root. Compare
+            # both sides in the host path domain: the resolver's stdout is a
+            # POSIX-style path under Git Bash (see host_realpath).
             if resolved:
                 self.assertTrue(
-                    os.path.realpath(resolved).startswith(os.path.realpath(str(root))),
+                    host_realpath(resolved).startswith(os.path.realpath(str(root))),
                     f"resolved path escaped root: {resolved!r}",
                 )
 

--- a/tests/test_path_fix.py
+++ b/tests/test_path_fix.py
@@ -29,10 +29,12 @@ class SessionCatchupPathSanitizeTests(unittest.TestCase):
         project_dir = session_catchup.get_project_dir_claude(project_path)
         return project_dir.name
 
+    @unittest.skipUnless(os.name == "nt", "Windows-shaped input; on POSIX Path.resolve() treats C:/... as relative and prepends the CWD")
     def test_windows_native_path(self) -> None:
         result = self._sanitized_name("C:/Users/oasrvadmin/Documents/planning-with-files-repo")
         self.assertEqual(result, "C--Users-oasrvadmin-Documents-planning-with-files-repo")
 
+    @unittest.skipUnless(os.name == "nt", "Windows-shaped input; on POSIX Path.resolve() treats C:/... as relative and prepends the CWD")
     def test_git_bash_path(self) -> None:
         result = self._sanitized_name("/c/Users/oasrvadmin/Documents/planning-with-files-repo")
         self.assertEqual(result, "C--Users-oasrvadmin-Documents-planning-with-files-repo")


### PR DESCRIPTION
## What changed

Two test-side portability fixes, no production script changes:

1. `tests/test_containment.py`: added a `host_realpath()` helper that maps the resolver's sh-emitted POSIX-style path back to its Windows form with `cygpath` before canonicalizing, and used it on the comparison side of the containment assertion.
2. `tests/test_path_fix.py`: restricted `test_windows_native_path` and `test_git_bash_path` to Windows with `skipUnless(os.name == "nt")`, mirroring the existing `skipIf` on the Unix vector in the same file.

## Why

Running the suite on GitHub-hosted runners for the first time (see #197) exposed both as latent failures:

- On `windows-latest` the runner can create symlinks, unlike most local Windows setups, so the escaping-symlink containment test actually runs there. It failed because the resolver prints a Git Bash POSIX path (`/tmp/...`, the mounted user temp dir) while the assertion canonicalized it with `os.path.realpath`, which reads it as `C:\tmp`. The resolver rejected the escape correctly; only the comparison was wrong. This is the same comparison-side normalization class as 0d028d4.
- On `ubuntu-latest` the two Windows-shaped sanitizer vectors failed because `Path.resolve()` treats `C:/Users/...` as a relative path on POSIX and prepends the CWD. On POSIX hosts the sanitizer only ever receives real POSIX paths in production, so the branch under test is Windows-only and the honest fix is to run those vectors only where their input shape is meaningful.

## How I tested it

- Local Windows 11 (symlink-capable, so the containment test runs rather than skips): `python -m pytest tests/ -q` goes from `1 failed, 201 passed, 3 skipped` to `202 passed, 3 skipped`.
- GitHub-hosted runners via my fork: failing run before the fixes https://github.com/Yigtwxx/planning-with-files/actions/runs/28927948152, green run after them https://github.com/Yigtwxx/planning-with-files/actions/runs/28928254774 (both `ubuntu-latest` and `windows-latest`).

## Limitations / notes

- `host_realpath()` falls back to the raw path when `cygpath` is absent; with Git Bash providing `sh` (the guard for the whole test class) `cygpath` is present in practice.
- The two skipped vectors keep full coverage on Windows, which is the platform the guarded regression (v3.2.0 sanitization fix) targets.

Addresses #197 (part 1 of 2; the CI workflow PR builds on this to land green).
