### PR TITLE
ci: run pytest on ubuntu and windows plus Pi extension vitest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,63 @@
+# Tests: runs the pytest suite on Linux and Windows plus the Pi extension
+# vitest suite on every PR and push to master.
+# The pytest suite also runs scripts/sync-ide-folders.py --verify via
+# tests/test_canonical_script_sync.py, so cross-copy parity is covered.
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install test dependencies
+        # pyyaml is optional at test time; without it the YAML frontmatter
+        # test in tests/test_skill_frontmatter_valid.py silently skips.
+        run: python -m pip install pytest pyyaml
+      - name: Assert sh is available
+        # Many hook tests guard on shutil.which("sh") and skip when absent.
+        # Fail loudly instead of silently losing coverage (Git Bash provides
+        # sh.exe on windows-latest).
+        run: python -c "import shutil, sys; sys.exit(0 if shutil.which('sh') else 1)"
+      - name: Run pytest
+        run: python -m pytest tests/ -q
+
+  vitest:
+    name: vitest (Pi extension)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: .pi/skills/planning-with-files/extensions/planning-with-files
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install dependencies
+        # No lockfile is committed for this package, so npm ci is not usable.
+        run: npm install --no-audit --no-fund
+      - name: Run vitest
+        run: npm test

--- a/tests/test_containment.py
+++ b/tests/test_containment.py
@@ -32,6 +32,29 @@ def have_sh() -> bool:
     return shutil.which("sh") is not None
 
 
+def host_realpath(sh_path: str) -> str:
+    """Canonicalize a path emitted by an sh script for host-side comparison.
+
+    Under Git Bash on Windows the resolver prints POSIX-style paths, and the
+    user temp directory is mounted at /tmp, so os.path.realpath on the raw
+    string would resolve against a nonexistent C:\\tmp and the containment
+    assertion would fail even though the resolved dir is contained. Map the
+    path back to its Windows form with cygpath first, then canonicalize.
+    """
+    if os.name == "nt" and sh_path.startswith("/"):
+        cygpath = shutil.which("cygpath")
+        if cygpath:
+            mapped = subprocess.run(
+                [cygpath, "-w", sh_path],
+                text=True,
+                capture_output=True,
+                check=False,
+            ).stdout.strip()
+            if mapped:
+                sh_path = mapped
+    return os.path.realpath(sh_path)
+
+
 def can_make_escaping_symlink() -> bool:
     """True only if we can create a dir symlink that realpath sees escaping root.
 
@@ -123,10 +146,12 @@ class ContainmentTests(unittest.TestCase):
                 resolved.endswith("escape"),
                 f"escaping symlink dir must be rejected, got {resolved!r}",
             )
-            # And the resolved path (if any) must stay under the root.
+            # And the resolved path (if any) must stay under the root. Compare
+            # both sides in the host path domain: the resolver's stdout is a
+            # POSIX-style path under Git Bash (see host_realpath).
             if resolved:
                 self.assertTrue(
-                    os.path.realpath(resolved).startswith(os.path.realpath(str(root))),
+                    host_realpath(resolved).startswith(os.path.realpath(str(root))),
                     f"resolved path escaped root: {resolved!r}",
                 )
 

--- a/tests/test_path_fix.py
+++ b/tests/test_path_fix.py
@@ -29,10 +29,12 @@ class SessionCatchupPathSanitizeTests(unittest.TestCase):
         project_dir = session_catchup.get_project_dir_claude(project_path)
         return project_dir.name
 
+    @unittest.skipUnless(os.name == "nt", "Windows-shaped input; on POSIX Path.resolve() treats C:/... as relative and prepends the CWD")
     def test_windows_native_path(self) -> None:
         result = self._sanitized_name("C:/Users/oasrvadmin/Documents/planning-with-files-repo")
         self.assertEqual(result, "C--Users-oasrvadmin-Documents-planning-with-files-repo")
 
+    @unittest.skipUnless(os.name == "nt", "Windows-shaped input; on POSIX Path.resolve() treats C:/... as relative and prepends the CWD")
     def test_git_bash_path(self) -> None:
         result = self._sanitized_name("/c/Users/oasrvadmin/Documents/planning-with-files-repo")
         self.assertEqual(result, "C--Users-oasrvadmin-Documents-planning-with-files-repo")


### PR DESCRIPTION
## What changed

Adds `.github/workflows/tests.yml` with two jobs:

- `pytest` on a matrix of `ubuntu-latest` and `windows-latest`, running `python -m pytest tests/ -q` on Python 3.12.
- `vitest` for the Pi extension on `ubuntu-latest` (`npm install` + `npm test` in `.pi/skills/planning-with-files/extensions/planning-with-files`, Node 22).

Triggers: `pull_request` and `push` to master, plus `workflow_dispatch`. Top-level permissions are `contents: read` only, with concurrency cancellation per ref.

## Why

CONTRIBUTING.md asks contributors to run the pytest suite before opening a PR, but no workflow enforces it; the only CI today is the Tessl skill review, which looks at SKILL.md prose rather than behavior. Windows regressions are a recurring bug class in this project (the v3.2.0 audit found `session-catchup.py` silently non-functional on Windows), and the `windows-latest` leg catches that class at PR time. Full background in #197.

## Design decisions

- `fail-fast: false` so a Windows-only failure is always reported alongside the ubuntu result instead of being masked by a cancel.
- No path filters: in this repo Markdown is the product. The suite validates SKILL.md frontmatter, version parity across the 19 bump targets, and canonical-vs-mirror script sync, so a docs-only PR can absolutely break tests. Total runtime is a few minutes.
- An explicit "Assert sh is available" step: about ten test files guard on `shutil.which("sh")` and skip when it is absent, so a runner-image PATH regression would silently drop the hook tests. The assertion turns silent coverage loss into a loud failure.
- `pyyaml` is installed explicitly because `tests/test_skill_frontmatter_valid.py` skips silently without it, and that test guards the exact regression class that caused the v3.1.3 hotfix.
- No separate `sync-ide-folders.py --verify` step: `tests/test_canonical_script_sync.py` already runs it inside the suite.
- `npm install` rather than `npm ci` because the Pi extension package has no committed lockfile. Committing one and switching to `npm ci` would be a reasonable follow-up.
- vitest runs on ubuntu only: the extension is pure TypeScript with the Pi runtime mocked, so a Windows leg adds runtime without adding signal. The shell/PowerShell surface, where Windows parity actually matters, is covered by the pytest matrix.
- `tests/test_clear_recovery.sh` (standalone, never wired into pytest) is deliberately left out of this first iteration.

## How I tested it

Validated on real GitHub-hosted runners from my fork before opening this PR: all three jobs green on https://github.com/Yigtwxx/planning-with-files/actions/runs/28928254774 (`202 passed, 3 skipped` on ubuntu with the two symlink containment tests running, `201 passed, 4 skipped` equivalent profile on windows, `21 passed` vitest). Locally on Windows 11: full pytest suite green, vitest 21/21, `python scripts/sync-ide-folders.py --verify` exit 0.

## Limitations / notes

- This branch includes the commit from #198; that PR fixes the two latent test-portability failures the first runner execution exposed, and this workflow needs it to land green. Merge #198 first and this PR reduces to the single workflow file.
- Python is pinned to 3.12 (the version the suite is known green on). A version matrix can be added later if a floor is decided.
- Skipped-test counts legitimately differ per OS (exec-bit tests skip on Windows, Windows-shaped sanitizer vectors skip on POSIX, symlink tests skip where symlinks cannot be created).

Closes #197
