### PR TITLE
fix: make Codex Windows hooks protocol-safe

### DIFF
--- a/.codebuddy/skills/planning-with-files/scripts/resolve-plan-dir.sh
+++ b/.codebuddy/skills/planning-with-files/scripts/resolve-plan-dir.sh
@@ -72,7 +72,9 @@ is_within_root() {
     root_real="$(canonicalize "${PWD}")" || root_real=""
     cand_real="$(canonicalize "${candidate}")" || cand_real=""
     if [ -z "${root_real}" ] || [ -z "${cand_real}" ]; then
-        return 0
+        # Slug validation blocks textual traversal, but only successful
+        # canonicalization can rule out a symlink/junction escape.
+        return 1
     fi
     case "${cand_real}" in
         "${root_real}"|"${root_real}"/*) return 0 ;;
@@ -119,6 +121,12 @@ resolve_from_env() {
 resolve_from_active_file() {
     [ -f "${ACTIVE_FILE}" ] || return 1
     plan_id="$(tr -d '\r\n[:space:]' < "${ACTIVE_FILE}")"
+    # UTF-8 BOM is not part of the plan id. POSIX printf octal escapes keep
+    # this portable across GNU/BSD sed variants and Git-for-Windows sh.
+    utf8_bom="$(printf '\357\273\277')"
+    case "${plan_id}" in
+        "${utf8_bom}"*) plan_id="${plan_id#"${utf8_bom}"}" ;;
+    esac
     slug_is_valid "${plan_id}" || return 1
     candidate="${PLAN_ROOT}/${plan_id}"
     if [ -d "${candidate}" ] && is_within_root "${candidate}"; then

--- a/.codebuddy/skills/planning-with-files/scripts/session-catchup.py
+++ b/.codebuddy/skills/planning-with-files/scripts/session-catchup.py
@@ -14,6 +14,30 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+
+def configure_utf8_stdio() -> None:
+    """Make catchup output deterministic on Windows legacy code pages.
+
+    Codex sessions and planning files are UTF-8 and can contain arbitrary
+    Unicode. Windows PowerShell may nevertheless launch Python with a cp1252
+    (or another OEM/ANSI) stdout codec. A report containing Chinese text then
+    used to fail at the first ``print`` with ``UnicodeEncodeError``. Configure
+    both streams before any report is emitted; ``errors='replace'`` also keeps
+    this advisory hook fail-safe if a malformed surrogate reaches the output.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, 'reconfigure', None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding='utf-8', errors='replace')
+            except (OSError, ValueError):
+                # Replaced/captured streams may not permit reconfiguration.
+                # The hook remains advisory, so retain the existing stream.
+                pass
+
+
+configure_utf8_stdio()
+
 try:
     import orjson
 except ImportError:

--- a/.codebuddy/skills/planning-with-files/scripts/set-active-plan.ps1
+++ b/.codebuddy/skills/planning-with-files/scripts/set-active-plan.ps1
@@ -1,8 +1,8 @@
 # planning-with-files: set or display the active plan pointer (PowerShell).
 #
 # Usage:
-#   .\set-active-plan.ps1 <plan_id>   — pin .planning\.active_plan to plan_id
-#   .\set-active-plan.ps1             — print the current active plan (if any)
+#   .\set-active-plan.ps1 <plan_id>   - pin .planning\.active_plan to plan_id
+#   .\set-active-plan.ps1             - print the current active plan (if any)
 
 param(
     [string]$PlanId = ""
@@ -19,7 +19,7 @@ if ($PlanId -eq "") {
             Write-Output "Active plan: $current"
             Write-Output "Path: $planDir"
         } elseif ($current -ne "") {
-            Write-Output "Active plan pointer: $current (directory not found — stale pointer)"
+            Write-Output "Active plan pointer: $current (directory not found - stale pointer)"
         } else {
             Write-Output "No active plan set."
         }
@@ -41,7 +41,8 @@ if (-not (Test-Path $PlanRoot)) {
     New-Item -ItemType Directory -Path $PlanRoot -Force | Out-Null
 }
 
-Set-Content -Path $ActiveFile -Value $PlanId -Encoding UTF8 -NoNewline
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($ActiveFile, $PlanId, $utf8NoBom)
 
 Write-Output "Active plan set to: $PlanId"
 Write-Output "Path: $PlanDir"

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume",
+        "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
             "type": "command",

--- a/.codex/hooks/codex_hook_adapter.py
+++ b/.codex/hooks/codex_hook_adapter.py
@@ -59,7 +59,7 @@ def is_session_attached(root: Path, session_id: str | None) -> bool:
 def emit_json(payload: dict[str, Any]) -> None:
     if not payload:
         return
-    json.dump(payload, sys.stdout, ensure_ascii=False)
+    json.dump(payload, sys.stdout, ensure_ascii=True)
     sys.stdout.write("\n")
 
 
@@ -107,7 +107,7 @@ def _windows_git_bash() -> tuple[str | None, list[str]]:
     return None, []
 
 
-def run_shell_script(script_name: str, cwd: Path) -> tuple[str, str]:
+def run_shell_script(script_name: str, cwd: Path, *args: str) -> tuple[str, str]:
     sh_cmd = "sh"
     env = None
     if os.name == "nt":
@@ -126,9 +126,11 @@ def run_shell_script(script_name: str, cwd: Path) -> tuple[str, str]:
         env.setdefault("PYTHON_BIN", sys.executable)
 
     result = subprocess.run(
-        [sh_cmd, str(HOOK_DIR / script_name)],
+        [sh_cmd, str(HOOK_DIR / script_name), *args],
         cwd=str(cwd),
         text=True,
+        encoding="utf-8",
+        errors="replace",
         capture_output=True,
         check=False,
         env=env,

--- a/.codex/hooks/permission_request.py
+++ b/.codex/hooks/permission_request.py
@@ -17,7 +17,10 @@ def main() -> None:
     if not adapter.is_session_attached(root, adapter.session_id_from_payload(payload)):
         return
 
-    plan = root / "task_plan.md"
+    # Pass a relative plan root so the shell resolver returns a path that is
+    # valid in both Git Bash and native Windows Python.
+    plan_dir, _ = adapter.run_shell_script("resolve-plan-dir.sh", root, ".planning")
+    plan = root / plan_dir / "task_plan.md" if plan_dir else root / "task_plan.md"
     if not plan.exists():
         return
 

--- a/.codex/hooks/pre_tool_use.py
+++ b/.codex/hooks/pre_tool_use.py
@@ -9,7 +9,6 @@ def main() -> None:
     root = adapter.cwd_from_payload(payload)
 
     if not adapter.is_session_attached(root, adapter.session_id_from_payload(payload)):
-        adapter.emit_json({"decision": "allow"})
         return
 
     stdout, stderr = adapter.run_shell_script("pre-tool-use.sh", root)
@@ -21,7 +20,12 @@ def main() -> None:
         return
 
     if stderr:
-        adapter.emit_json({"systemMessage": stderr})
+        adapter.emit_json({
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": stderr,
+            }
+        })
 
 
 if __name__ == "__main__":

--- a/.codex/hooks/resolve-plan-dir.sh
+++ b/.codex/hooks/resolve-plan-dir.sh
@@ -1,76 +1,14 @@
 #!/bin/sh
-# planning-with-files: resolve active plan directory.
+# planning-with-files: global Codex hook resolver entry point.
 #
-# Resolution order:
-#   1. $PLAN_ID env var → ./.planning/$PLAN_ID/ if exists
-#   2. ./.planning/.active_plan content → matching dir if exists
-#   3. Newest ./.planning/<dir>/ by mtime
-#   4. Otherwise empty stdout (caller falls back to legacy ./task_plan.md)
-#
-# Always exits 0. Never errors out the agent loop.
-#
-# Usage:
-#   PLAN_DIR="$(sh scripts/resolve-plan-dir.sh)"
-#   PLAN_FILE="${PLAN_DIR:+$PLAN_DIR/}task_plan.md"
+# The resolver implementation is owned by the installed skill. Keep this file
+# as a thin forwarding shim so Hook and helper callers cannot silently drift
+# onto different slug/containment rules again.
 
 set -u
 
-PLAN_ROOT="${1:-${PWD}/.planning}"
-ACTIVE_FILE="${PLAN_ROOT}/.active_plan"
+HOOK_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" 2>/dev/null && pwd)" || exit 0
+CANONICAL_RESOLVER="${HOOK_DIR}/../skills/planning-with-files/scripts/resolve-plan-dir.sh"
 
-resolve_from_env() {
-    plan_id="${PLAN_ID:-}"
-    [ -z "${plan_id}" ] && return 1
-    candidate="${PLAN_ROOT}/${plan_id}"
-    if [ -d "${candidate}" ]; then
-        printf "%s\n" "${candidate}"
-        return 0
-    fi
-    return 1
-}
-
-resolve_from_active_file() {
-    [ -f "${ACTIVE_FILE}" ] || return 1
-    plan_id="$(tr -d '\r\n' < "${ACTIVE_FILE}")"
-    [ -z "${plan_id}" ] && return 1
-    candidate="${PLAN_ROOT}/${plan_id}"
-    if [ -d "${candidate}" ]; then
-        printf "%s\n" "${candidate}"
-        return 0
-    fi
-    return 1
-}
-
-resolve_latest_dir() {
-    [ -d "${PLAN_ROOT}" ] || return 1
-    # Portable newest-mtime selector. Avoid `ls -t` BSD/GNU drift.
-    # Only consider dirs that contain task_plan.md — skips system dirs like sessions/.
-    latest=""
-    latest_mtime=0
-    for entry in "${PLAN_ROOT}"/*/; do
-        [ -d "${entry}" ] || continue
-        # Strip trailing slash
-        clean="${entry%/}"
-        # Skip hidden dirs
-        case "$(basename "${clean}")" in
-            .*) continue ;;
-        esac
-        # Skip dirs that are not plan dirs
-        [ -f "${clean}/task_plan.md" ] || continue
-        mtime="$(date -r "${clean}" +%s 2>/dev/null || stat -c '%Y' "${clean}" 2>/dev/null || echo 0)"
-        if [ "${mtime}" -gt "${latest_mtime}" ] 2>/dev/null; then
-            latest_mtime="${mtime}"
-            latest="${clean}"
-        fi
-    done
-    if [ -n "${latest}" ]; then
-        printf "%s\n" "${latest}"
-        return 0
-    fi
-    return 1
-}
-
-if resolve_from_env; then exit 0; fi
-if resolve_from_active_file; then exit 0; fi
-if resolve_latest_dir; then exit 0; fi
-exit 0
+[ -f "${CANONICAL_RESOLVER}" ] || exit 0
+exec sh "${CANONICAL_RESOLVER}" "$@"

--- a/.codex/hooks/run_sh.py
+++ b/.codex/hooks/run_sh.py
@@ -13,6 +13,7 @@ hook runs and print its stdout. Never used on unix. Always exits 0.
 """
 from __future__ import annotations
 
+import json
 import sys
 
 import codex_hook_adapter as adapter
@@ -25,8 +26,32 @@ def main() -> None:
     payload = adapter.load_payload()
     root = adapter.cwd_from_payload(payload)
     stdout, _ = adapter.run_shell_script(script_name, root)
-    if stdout:
-        sys.stdout.write(stdout + "\n")
+    if not stdout:
+        return
+
+    context_events = {
+        "session-start.sh": "SessionStart",
+        "user-prompt-submit.sh": "UserPromptSubmit",
+    }
+    if script_name in context_events:
+        result = {
+            "hookSpecificOutput": {
+                "hookEventName": context_events[script_name],
+                "additionalContext": stdout,
+            }
+        }
+        sys.stdout.write(json.dumps(result, ensure_ascii=True) + "\n")
+        return
+
+    if script_name == "pre-compact.sh":
+        result = {
+            "continue": True,
+            "systemMessage": stdout,
+        }
+        sys.stdout.write(json.dumps(result, ensure_ascii=True) + "\n")
+        return
+
+    sys.stdout.write(stdout + "\n")
 
 
 if __name__ == "__main__":

--- a/.codex/skills/planning-with-files/scripts/resolve-plan-dir.sh
+++ b/.codex/skills/planning-with-files/scripts/resolve-plan-dir.sh
@@ -72,7 +72,9 @@ is_within_root() {
     root_real="$(canonicalize "${PWD}")" || root_real=""
     cand_real="$(canonicalize "${candidate}")" || cand_real=""
     if [ -z "${root_real}" ] || [ -z "${cand_real}" ]; then
-        return 0
+        # Slug validation blocks textual traversal, but only successful
+        # canonicalization can rule out a symlink/junction escape.
+        return 1
     fi
     case "${cand_real}" in
         "${root_real}"|"${root_real}"/*) return 0 ;;
@@ -119,6 +121,12 @@ resolve_from_env() {
 resolve_from_active_file() {
     [ -f "${ACTIVE_FILE}" ] || return 1
     plan_id="$(tr -d '\r\n[:space:]' < "${ACTIVE_FILE}")"
+    # UTF-8 BOM is not part of the plan id. POSIX printf octal escapes keep
+    # this portable across GNU/BSD sed variants and Git-for-Windows sh.
+    utf8_bom="$(printf '\357\273\277')"
+    case "${plan_id}" in
+        "${utf8_bom}"*) plan_id="${plan_id#"${utf8_bom}"}" ;;
+    esac
     slug_is_valid "${plan_id}" || return 1
     candidate="${PLAN_ROOT}/${plan_id}"
     if [ -d "${candidate}" ] && is_within_root "${candidate}"; then

--- a/.codex/skills/planning-with-files/scripts/session-catchup.py
+++ b/.codex/skills/planning-with-files/scripts/session-catchup.py
@@ -14,6 +14,30 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+
+def configure_utf8_stdio() -> None:
+    """Make catchup output deterministic on Windows legacy code pages.
+
+    Codex sessions and planning files are UTF-8 and can contain arbitrary
+    Unicode. Windows PowerShell may nevertheless launch Python with a cp1252
+    (or another OEM/ANSI) stdout codec. A report containing Chinese text then
+    used to fail at the first ``print`` with ``UnicodeEncodeError``. Configure
+    both streams before any report is emitted; ``errors='replace'`` also keeps
+    this advisory hook fail-safe if a malformed surrogate reaches the output.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, 'reconfigure', None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding='utf-8', errors='replace')
+            except (OSError, ValueError):
+                # Replaced/captured streams may not permit reconfiguration.
+                # The hook remains advisory, so retain the existing stream.
+                pass
+
+
+configure_utf8_stdio()
+
 try:
     import orjson
 except ImportError:

--- a/.codex/skills/planning-with-files/scripts/set-active-plan.ps1
+++ b/.codex/skills/planning-with-files/scripts/set-active-plan.ps1
@@ -1,8 +1,8 @@
 # planning-with-files: set or display the active plan pointer (PowerShell).
 #
 # Usage:
-#   .\set-active-plan.ps1 <plan_id>   — pin .planning\.active_plan to plan_id
-#   .\set-active-plan.ps1             — print the current active plan (if any)
+#   .\set-active-plan.ps1 <plan_id>   - pin .planning\.active_plan to plan_id
+#   .\set-active-plan.ps1             - print the current active plan (if any)
 
 param(
     [string]$PlanId = ""
@@ -19,7 +19,7 @@ if ($PlanId -eq "") {
             Write-Output "Active plan: $current"
             Write-Output "Path: $planDir"
         } elseif ($current -ne "") {
-            Write-Output "Active plan pointer: $current (directory not found — stale pointer)"
+            Write-Output "Active plan pointer: $current (directory not found - stale pointer)"
         } else {
             Write-Output "No active plan set."
         }
@@ -41,7 +41,8 @@ if (-not (Test-Path $PlanRoot)) {
     New-Item -ItemType Directory -Path $PlanRoot -Force | Out-Null
 }
 
-Set-Content -Path $ActiveFile -Value $PlanId -Encoding UTF8 -NoNewline
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($ActiveFile, $PlanId, $utf8NoBom)
 
 Write-Output "Active plan set to: $PlanId"
 Write-Output "Path: $PlanDir"

--- a/.continue/skills/planning-with-files/scripts/resolve-plan-dir.sh
+++ b/.continue/skills/planning-with-files/scripts/resolve-plan-dir.sh
@@ -72,7 +72,9 @@ is_within_root() {
     root_real="$(canonicalize "${PWD}")" || root_real=""
     cand_real="$(canonicalize "${candidate}")" || cand_real=""
     if [ -z "${root_real}" ] || [ -z "${cand_real}" ]; then
-        return 0
+        # Slug validation blocks textual traversal, but only successful
+        # canonicalization can rule out a symlink/junction escape.
+        return 1
     fi
     case "${cand_real}" in
         "${root_real}"|"${root_real}"/*) return 0 ;;
@@ -119,6 +121,12 @@ resolve_from_env() {
 resolve_from_active_file() {
     [ -f "${ACTIVE_FILE}" ] || return 1
     plan_id="$(tr -d '\r\n[:space:]' < "${ACTIVE_FILE}")"
+    # UTF-8 BOM is not part of the plan id. POSIX printf octal escapes keep
+    # this portable across GNU/BSD sed variants and Git-for-Windows sh.
+    utf8_bom="$(printf '\357\273\277')"
+    case "${plan_id}" in
+        "${utf8_bom}"*) plan_id="${plan_id#"${utf8_bom}"}" ;;
+    esac
     slug_is_valid "${plan_id}" || return 1
     candidate="${PLAN_ROOT}/${plan_id}"
     if [ -d "${candidate}" ] && is_within_root "${candidate}"; then

--- a/.continue/skills/planning-with-files/scripts/session-catchup.py
+++ b/.continue/skills/planning-with-files/scripts/session-catchup.py
@@ -14,6 +14,30 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+
+def configure_utf8_stdio() -> None:
+    """Make catchup output deterministic on Windows legacy code pages.
+
+    Codex sessions and planning files are UTF-8 and can contain arbitrary
+    Unicode. Windows PowerShell may nevertheless launch Python with a cp1252
+    (or another OEM/ANSI) stdout codec. A report containing Chinese text then
+    used to fail at the first ``print`` with ``UnicodeEncodeError``. Configure
+    both streams before any report is emitted; ``errors='replace'`` also keeps
+    this advisory hook fail-safe if a malformed surrogate reaches the output.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, 'reconfigure', None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding='utf-8', errors='replace')
+            except (OSError, ValueError):
+                # Replaced/captured streams may not permit reconfiguration.
+                # The hook remains advisory, so retain the existing stream.
+                pass
+
+
+configure_utf8_stdio()
+
 try:
     import orjson
 except ImportError:

--- a/.continue/skills/planning-with-files/scripts/set-active-plan.ps1
+++ b/.continue/skills/planning-with-files/scripts/set-active-plan.ps1
@@ -1,8 +1,8 @@
 # planning-with-files: set or display the active plan pointer (PowerShell).
 #
 # Usage:
-#   .\set-active-plan.ps1 <plan_id>   — pin .planning\.active_plan to plan_id
-#   .\set-active-plan.ps1             — print the current active plan (if any)
+#   .\set-active-plan.ps1 <plan_id>   - pin .planning\.active_plan to plan_id
+#   .\set-active-plan.ps1             - print the current active plan (if any)
 
 param(
     [string]$PlanId = ""
@@ -19,7 +19,7 @@ if ($PlanId -eq "") {
             Write-Output "Active plan: $current"
             Write-Output "Path: $planDir"
         } elseif ($current -ne "") {
-            Write-Output "Active plan pointer: $current (directory not found — stale pointer)"
+            Write-Output "Active plan pointer: $current (directory not found - stale pointer)"
         } else {
             Write-Output "No active plan set."
         }
@@ -41,7 +41,8 @@ if (-not (Test-Path $PlanRoot)) {
     New-Item -ItemType Directory -Path $PlanRoot -Force | Out-Null
 }
 
-Set-Content -Path $ActiveFile -Value $PlanId -Encoding UTF8 -NoNewline
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($ActiveFile, $PlanId, $utf8NoBom)
 
 Write-Output "Active plan set to: $PlanId"
 Write-Output "Path: $PlanDir"

--- a/.factory/skills/planning-with-files/scripts/resolve-plan-dir.sh
+++ b/.factory/skills/planning-with-files/scripts/resolve-plan-dir.sh
@@ -72,7 +72,9 @@ is_within_root() {
     root_real="$(canonicalize "${PWD}")" || root_real=""
     cand_real="$(canonicalize "${candidate}")" || cand_real=""
     if [ -z "${root_real}" ] || [ -z "${cand_real}" ]; then
-        return 0
+        # Slug validation blocks textual traversal, but only successful
+        # canonicalization can rule out a symlink/junction escape.
+        return 1
     fi
     case "${cand_real}" in
         "${root_real}"|"${root_real}"/*) return 0 ;;
@@ -119,6 +121,12 @@ resolve_from_env() {
 resolve_from_active_file() {
     [ -f "${ACTIVE_FILE}" ] || return 1
     plan_id="$(tr -d '\r\n[:space:]' < "${ACTIVE_FILE}")"
+    # UTF-8 BOM is not part of the plan id. POSIX printf octal escapes keep
+    # this portable across GNU/BSD sed variants and Git-for-Windows sh.
+    utf8_bom="$(printf '\357\273\277')"
+    case "${plan_id}" in
+        "${utf8_bom}"*) plan_id="${plan_id#"${utf8_bom}"}" ;;
+    esac
     slug_is_valid "${plan_id}" || return 1
     candidate="${PLAN_ROOT}/${plan_id}"
     if [ -d "${candidate}" ] && is_within_root "${candidate}"; then

--- a/.factory/skills/planning-with-files/scripts/session-catchup.py
+++ b/.factory/skills/planning-with-files/scripts/session-catchup.py
@@ -14,6 +14,30 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+
+def configure_utf8_stdio() -> None:
+    """Make catchup output deterministic on Windows legacy code pages.
+
+    Codex sessions and planning files are UTF-8 and can contain arbitrary
+    Unicode. Windows PowerShell may nevertheless launch Python with a cp1252
+    (or another OEM/ANSI) stdout codec. A report containing Chinese text then
+    used to fail at the first ``print`` with ``UnicodeEncodeError``. Configure
+    both streams before any report is emitted; ``errors='replace'`` also keeps
+    this advisory hook fail-safe if a malformed surrogate reaches the output.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, 'reconfigure', None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding='utf-8', errors='replace')
+            except (OSError, ValueError):
+                # Replaced/captured streams may not permit reconfiguration.
+                # The hook remains advisory, so retain the existing stream.
+                pass
+
+
+configure_utf8_stdio()
+
 try:
     import orjson
 except ImportError:

--- a/.factory/skills/planning-with-files/scripts/set-active-plan.ps1
+++ b/.factory/skills/planning-with-files/scripts/set-active-plan.ps1
@@ -1,8 +1,8 @@
 # planning-with-files: set or display the active plan pointer (PowerShell).
 #
 # Usage:
-#   .\set-active-plan.ps1 <plan_id>   — pin .planning\.active_plan to plan_id
-#   .\set-active-plan.ps1             — print the current active plan (if any)
+#   .\set-active-plan.ps1 <plan_id>   - pin .planning\.active_plan to plan_id
+#   .\set-active-plan.ps1             - print the current active plan (if any)
 
 param(
     [string]$PlanId = ""
@@ -19,7 +19,7 @@ if ($PlanId -eq "") {
             Write-Output "Active plan: $current"
             Write-Output "Path: $planDir"
         } elseif ($current -ne "") {
-            Write-Output "Active plan pointer: $current (directory not found — stale pointer)"
+            Write-Output "Active plan pointer: $current (directory not found - stale pointer)"
         } else {
             Write-Output "No active plan set."
         }
@@ -41,7 +41,8 @@ if (-not (Test-Path $PlanRoot)) {
     New-Item -ItemType Directory -Path $PlanRoot -Force | Out-Null
 }
 
-Set-Content -Path $ActiveFile -Value $PlanId -Encoding UTF8 -NoNewline
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($ActiveFile, $PlanId, $utf8NoBom)
 
 Write-Output "Active plan set to: $PlanId"
 Write-Output "Path: $PlanDir"

--- a/.gemini/skills/planning-with-files/scripts/resolve-plan-dir.sh
+++ b/.gemini/skills/planning-with-files/scripts/resolve-plan-dir.sh
@@ -72,7 +72,9 @@ is_within_root() {
     root_real="$(canonicalize "${PWD}")" || root_real=""
     cand_real="$(canonicalize "${candidate}")" || cand_real=""
     if [ -z "${root_real}" ] || [ -z "${cand_real}" ]; then
-        return 0
+        # Slug validation blocks textual traversal, but only successful
+        # canonicalization can rule out a symlink/junction escape.
+        return 1
     fi
     case "${cand_real}" in
         "${root_real}"|"${root_real}"/*) return 0 ;;
@@ -119,6 +121,12 @@ resolve_from_env() {
 resolve_from_active_file() {
     [ -f "${ACTIVE_FILE}" ] || return 1
     plan_id="$(tr -d '\r\n[:space:]' < "${ACTIVE_FILE}")"
+    # UTF-8 BOM is not part of the plan id. POSIX printf octal escapes keep
+    # this portable across GNU/BSD sed variants and Git-for-Windows sh.
+    utf8_bom="$(printf '\357\273\277')"
+    case "${plan_id}" in
+        "${utf8_bom}"*) plan_id="${plan_id#"${utf8_bom}"}" ;;
+    esac
     slug_is_valid "${plan_id}" || return 1
     candidate="${PLAN_ROOT}/${plan_id}"
     if [ -d "${candidate}" ] && is_within_root "${candidate}"; then

--- a/.gemini/skills/planning-with-files/scripts/session-catchup.py
+++ b/.gemini/skills/planning-with-files/scripts/session-catchup.py
@@ -14,6 +14,30 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+
+def configure_utf8_stdio() -> None:
+    """Make catchup output deterministic on Windows legacy code pages.
+
+    Codex sessions and planning files are UTF-8 and can contain arbitrary
+    Unicode. Windows PowerShell may nevertheless launch Python with a cp1252
+    (or another OEM/ANSI) stdout codec. A report containing Chinese text then
+    used to fail at the first ``print`` with ``UnicodeEncodeError``. Configure
+    both streams before any report is emitted; ``errors='replace'`` also keeps
+    this advisory hook fail-safe if a malformed surrogate reaches the output.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, 'reconfigure', None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding='utf-8', errors='replace')
+            except (OSError, ValueError):
+                # Replaced/captured streams may not permit reconfiguration.
+                # The hook remains advisory, so retain the existing stream.
+                pass
+
+
+configure_utf8_stdio()
+
 try:
     import orjson
 except ImportError:

--- a/.gemini/skills/planning-with-files/scripts/set-active-plan.ps1
+++ b/.gemini/skills/planning-with-files/scripts/set-active-plan.ps1
@@ -1,8 +1,8 @@
 # planning-with-files: set or display the active plan pointer (PowerShell).
 #
 # Usage:
-#   .\set-active-plan.ps1 <plan_id>   — pin .planning\.active_plan to plan_id
-#   .\set-active-plan.ps1             — print the current active plan (if any)
+#   .\set-active-plan.ps1 <plan_id>   - pin .planning\.active_plan to plan_id
+#   .\set-active-plan.ps1             - print the current active plan (if any)
 
 param(
     [string]$PlanId = ""
@@ -19,7 +19,7 @@ if ($PlanId -eq "") {
             Write-Output "Active plan: $current"
             Write-Output "Path: $planDir"
         } elseif ($current -ne "") {
-            Write-Output "Active plan pointer: $current (directory not found — stale pointer)"
+            Write-Output "Active plan pointer: $current (directory not found - stale pointer)"
         } else {
             Write-Output "No active plan set."
         }
@@ -41,7 +41,8 @@ if (-not (Test-Path $PlanRoot)) {
     New-Item -ItemType Directory -Path $PlanRoot -Force | Out-Null
 }
 
-Set-Content -Path $ActiveFile -Value $PlanId -Encoding UTF8 -NoNewline
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($ActiveFile, $PlanId, $utf8NoBom)
 
 Write-Output "Active plan set to: $PlanId"
 Write-Output "Path: $PlanDir"

--- a/.pi/skills/planning-with-files/scripts/resolve-plan-dir.sh
+++ b/.pi/skills/planning-with-files/scripts/resolve-plan-dir.sh
@@ -72,7 +72,9 @@ is_within_root() {
     root_real="$(canonicalize "${PWD}")" || root_real=""
     cand_real="$(canonicalize "${candidate}")" || cand_real=""
     if [ -z "${root_real}" ] || [ -z "${cand_real}" ]; then
-        return 0
+        # Slug validation blocks textual traversal, but only successful
+        # canonicalization can rule out a symlink/junction escape.
+        return 1
     fi
     case "${cand_real}" in
         "${root_real}"|"${root_real}"/*) return 0 ;;
@@ -119,6 +121,12 @@ resolve_from_env() {
 resolve_from_active_file() {
     [ -f "${ACTIVE_FILE}" ] || return 1
     plan_id="$(tr -d '\r\n[:space:]' < "${ACTIVE_FILE}")"
+    # UTF-8 BOM is not part of the plan id. POSIX printf octal escapes keep
+    # this portable across GNU/BSD sed variants and Git-for-Windows sh.
+    utf8_bom="$(printf '\357\273\277')"
+    case "${plan_id}" in
+        "${utf8_bom}"*) plan_id="${plan_id#"${utf8_bom}"}" ;;
+    esac
     slug_is_valid "${plan_id}" || return 1
     candidate="${PLAN_ROOT}/${plan_id}"
     if [ -d "${candidate}" ] && is_within_root "${candidate}"; then

--- a/.pi/skills/planning-with-files/scripts/session-catchup.py
+++ b/.pi/skills/planning-with-files/scripts/session-catchup.py
@@ -14,6 +14,30 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+
+def configure_utf8_stdio() -> None:
+    """Make catchup output deterministic on Windows legacy code pages.
+
+    Codex sessions and planning files are UTF-8 and can contain arbitrary
+    Unicode. Windows PowerShell may nevertheless launch Python with a cp1252
+    (or another OEM/ANSI) stdout codec. A report containing Chinese text then
+    used to fail at the first ``print`` with ``UnicodeEncodeError``. Configure
+    both streams before any report is emitted; ``errors='replace'`` also keeps
+    this advisory hook fail-safe if a malformed surrogate reaches the output.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, 'reconfigure', None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding='utf-8', errors='replace')
+            except (OSError, ValueError):
+                # Replaced/captured streams may not permit reconfiguration.
+                # The hook remains advisory, so retain the existing stream.
+                pass
+
+
+configure_utf8_stdio()
+
 try:
     import orjson
 except ImportError:

--- a/.pi/skills/planning-with-files/scripts/set-active-plan.ps1
+++ b/.pi/skills/planning-with-files/scripts/set-active-plan.ps1
@@ -1,8 +1,8 @@
 # planning-with-files: set or display the active plan pointer (PowerShell).
 #
 # Usage:
-#   .\set-active-plan.ps1 <plan_id>   — pin .planning\.active_plan to plan_id
-#   .\set-active-plan.ps1             — print the current active plan (if any)
+#   .\set-active-plan.ps1 <plan_id>   - pin .planning\.active_plan to plan_id
+#   .\set-active-plan.ps1             - print the current active plan (if any)
 
 param(
     [string]$PlanId = ""
@@ -19,7 +19,7 @@ if ($PlanId -eq "") {
             Write-Output "Active plan: $current"
             Write-Output "Path: $planDir"
         } elseif ($current -ne "") {
-            Write-Output "Active plan pointer: $current (directory not found — stale pointer)"
+            Write-Output "Active plan pointer: $current (directory not found - stale pointer)"
         } else {
             Write-Output "No active plan set."
         }
@@ -41,7 +41,8 @@ if (-not (Test-Path $PlanRoot)) {
     New-Item -ItemType Directory -Path $PlanRoot -Force | Out-Null
 }
 
-Set-Content -Path $ActiveFile -Value $PlanId -Encoding UTF8 -NoNewline
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($ActiveFile, $PlanId, $utf8NoBom)
 
 Write-Output "Active plan set to: $PlanId"
 Write-Output "Path: $PlanDir"

--- a/scripts/resolve-plan-dir.sh
+++ b/scripts/resolve-plan-dir.sh
@@ -72,7 +72,9 @@ is_within_root() {
     root_real="$(canonicalize "${PWD}")" || root_real=""
     cand_real="$(canonicalize "${candidate}")" || cand_real=""
     if [ -z "${root_real}" ] || [ -z "${cand_real}" ]; then
-        return 0
+        # Slug validation blocks textual traversal, but only successful
+        # canonicalization can rule out a symlink/junction escape.
+        return 1
     fi
     case "${cand_real}" in
         "${root_real}"|"${root_real}"/*) return 0 ;;
@@ -119,6 +121,12 @@ resolve_from_env() {
 resolve_from_active_file() {
     [ -f "${ACTIVE_FILE}" ] || return 1
     plan_id="$(tr -d '\r\n[:space:]' < "${ACTIVE_FILE}")"
+    # UTF-8 BOM is not part of the plan id. POSIX printf octal escapes keep
+    # this portable across GNU/BSD sed variants and Git-for-Windows sh.
+    utf8_bom="$(printf '\357\273\277')"
+    case "${plan_id}" in
+        "${utf8_bom}"*) plan_id="${plan_id#"${utf8_bom}"}" ;;
+    esac
     slug_is_valid "${plan_id}" || return 1
     candidate="${PLAN_ROOT}/${plan_id}"
     if [ -d "${candidate}" ] && is_within_root "${candidate}"; then

--- a/scripts/set-active-plan.ps1
+++ b/scripts/set-active-plan.ps1
@@ -1,8 +1,8 @@
 # planning-with-files: set or display the active plan pointer (PowerShell).
 #
 # Usage:
-#   .\set-active-plan.ps1 <plan_id>   — pin .planning\.active_plan to plan_id
-#   .\set-active-plan.ps1             — print the current active plan (if any)
+#   .\set-active-plan.ps1 <plan_id>   - pin .planning\.active_plan to plan_id
+#   .\set-active-plan.ps1             - print the current active plan (if any)
 
 param(
     [string]$PlanId = ""
@@ -19,7 +19,7 @@ if ($PlanId -eq "") {
             Write-Output "Active plan: $current"
             Write-Output "Path: $planDir"
         } elseif ($current -ne "") {
-            Write-Output "Active plan pointer: $current (directory not found — stale pointer)"
+            Write-Output "Active plan pointer: $current (directory not found - stale pointer)"
         } else {
             Write-Output "No active plan set."
         }
@@ -41,7 +41,8 @@ if (-not (Test-Path $PlanRoot)) {
     New-Item -ItemType Directory -Path $PlanRoot -Force | Out-Null
 }
 
-Set-Content -Path $ActiveFile -Value $PlanId -Encoding UTF8 -NoNewline
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($ActiveFile, $PlanId, $utf8NoBom)
 
 Write-Output "Active plan set to: $PlanId"
 Write-Output "Path: $PlanDir"

--- a/skills/planning-with-files/scripts/resolve-plan-dir.sh
+++ b/skills/planning-with-files/scripts/resolve-plan-dir.sh
@@ -72,7 +72,9 @@ is_within_root() {
     root_real="$(canonicalize "${PWD}")" || root_real=""
     cand_real="$(canonicalize "${candidate}")" || cand_real=""
     if [ -z "${root_real}" ] || [ -z "${cand_real}" ]; then
-        return 0
+        # Slug validation blocks textual traversal, but only successful
+        # canonicalization can rule out a symlink/junction escape.
+        return 1
     fi
     case "${cand_real}" in
         "${root_real}"|"${root_real}"/*) return 0 ;;
@@ -119,6 +121,12 @@ resolve_from_env() {
 resolve_from_active_file() {
     [ -f "${ACTIVE_FILE}" ] || return 1
     plan_id="$(tr -d '\r\n[:space:]' < "${ACTIVE_FILE}")"
+    # UTF-8 BOM is not part of the plan id. POSIX printf octal escapes keep
+    # this portable across GNU/BSD sed variants and Git-for-Windows sh.
+    utf8_bom="$(printf '\357\273\277')"
+    case "${plan_id}" in
+        "${utf8_bom}"*) plan_id="${plan_id#"${utf8_bom}"}" ;;
+    esac
     slug_is_valid "${plan_id}" || return 1
     candidate="${PLAN_ROOT}/${plan_id}"
     if [ -d "${candidate}" ] && is_within_root "${candidate}"; then

--- a/skills/planning-with-files/scripts/session-catchup.py
+++ b/skills/planning-with-files/scripts/session-catchup.py
@@ -14,6 +14,30 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
+
+def configure_utf8_stdio() -> None:
+    """Make catchup output deterministic on Windows legacy code pages.
+
+    Codex sessions and planning files are UTF-8 and can contain arbitrary
+    Unicode. Windows PowerShell may nevertheless launch Python with a cp1252
+    (or another OEM/ANSI) stdout codec. A report containing Chinese text then
+    used to fail at the first ``print`` with ``UnicodeEncodeError``. Configure
+    both streams before any report is emitted; ``errors='replace'`` also keeps
+    this advisory hook fail-safe if a malformed surrogate reaches the output.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, 'reconfigure', None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding='utf-8', errors='replace')
+            except (OSError, ValueError):
+                # Replaced/captured streams may not permit reconfiguration.
+                # The hook remains advisory, so retain the existing stream.
+                pass
+
+
+configure_utf8_stdio()
+
 try:
     import orjson
 except ImportError:

--- a/skills/planning-with-files/scripts/set-active-plan.ps1
+++ b/skills/planning-with-files/scripts/set-active-plan.ps1
@@ -1,8 +1,8 @@
 # planning-with-files: set or display the active plan pointer (PowerShell).
 #
 # Usage:
-#   .\set-active-plan.ps1 <plan_id>   — pin .planning\.active_plan to plan_id
-#   .\set-active-plan.ps1             — print the current active plan (if any)
+#   .\set-active-plan.ps1 <plan_id>   - pin .planning\.active_plan to plan_id
+#   .\set-active-plan.ps1             - print the current active plan (if any)
 
 param(
     [string]$PlanId = ""
@@ -19,7 +19,7 @@ if ($PlanId -eq "") {
             Write-Output "Active plan: $current"
             Write-Output "Path: $planDir"
         } elseif ($current -ne "") {
-            Write-Output "Active plan pointer: $current (directory not found — stale pointer)"
+            Write-Output "Active plan pointer: $current (directory not found - stale pointer)"
         } else {
             Write-Output "No active plan set."
         }
@@ -41,7 +41,8 @@ if (-not (Test-Path $PlanRoot)) {
     New-Item -ItemType Directory -Path $PlanRoot -Force | Out-Null
 }
 
-Set-Content -Path $ActiveFile -Value $PlanId -Encoding UTF8 -NoNewline
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+[System.IO.File]::WriteAllText($ActiveFile, $PlanId, $utf8NoBom)
 
 Write-Output "Active plan set to: $PlanId"
 Write-Output "Path: $PlanDir"

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -29,13 +30,32 @@ class CodexHooksTests(unittest.TestCase):
         )
 
     def run_shell_hook(self, script_name: str, cwd: Path, env: dict | None = None) -> subprocess.CompletedProcess[str]:
+        shell_env = (env or os.environ).copy()
+        shell = shutil.which("sh", path=shell_env.get("PATH"))
+        if os.name == "nt":
+            sys.path.insert(0, str(HOOKS_DIR))
+            try:
+                import codex_hook_adapter as adapter
+
+                shell, extra_path_dirs = adapter._windows_git_bash()
+            finally:
+                sys.path.pop(0)
+            if shell is None:
+                raise unittest.SkipTest("Git for Windows sh.exe is unavailable")
+            if extra_path_dirs:
+                shell_env["PATH"] = os.pathsep.join(
+                    [*extra_path_dirs, shell_env.get("PATH", "")]
+                )
+            shell_env.setdefault("PYTHON_BIN", sys.executable)
+        elif shell is None:
+            raise unittest.SkipTest("POSIX sh is unavailable")
         return subprocess.run(
-            ["sh", str(HOOKS_DIR / script_name)],
+            [shell, str(HOOKS_DIR / script_name)],
             text=True,
             encoding="utf-8",
             capture_output=True,
             cwd=str(cwd),
-            env=env,
+            env=shell_env,
             check=False,
         )
 

--- a/tests/test_codex_hooks.py
+++ b/tests/test_codex_hooks.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 import subprocess
@@ -6,6 +7,7 @@ import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -64,6 +66,10 @@ class CodexHooksTests(unittest.TestCase):
             },
             set(payload["hooks"]),
         )
+        self.assertEqual(
+            "startup|resume|clear|compact",
+            payload["hooks"]["SessionStart"][0]["matcher"],
+        )
 
     def test_permission_request_adapter_emits_plan_reminder(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -96,6 +102,24 @@ class CodexHooksTests(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual("", result.stdout.strip())
 
+    def test_permission_request_resolves_scoped_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            plan_dir = root / ".planning" / "task-a"
+            plan_dir.mkdir(parents=True)
+            plan_dir.joinpath("task_plan.md").write_text("# Scoped Plan\n", encoding="utf-8")
+            root.joinpath(".planning", ".active_plan").write_text("task-a\n", encoding="utf-8")
+
+            result = self.run_python_hook(
+                "permission_request.py",
+                {"cwd": str(root), "tool_name": "Bash"},
+                root,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertIn("Active plan", payload["systemMessage"])
+
     def test_session_start_reuses_plan_context(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir, tempfile.TemporaryDirectory() as home:
             root = Path(tmpdir)
@@ -121,7 +145,7 @@ class CodexHooksTests(unittest.TestCase):
         self.assertIn("Ship Codex hooks", result.stdout)
         self.assertIn("Finished adapter draft", result.stdout)
 
-    def test_pre_tool_use_adapter_emits_system_message(self) -> None:
+    def test_pre_tool_use_adapter_emits_additional_context(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             root.joinpath("task_plan.md").write_text(
@@ -143,8 +167,25 @@ class CodexHooksTests(unittest.TestCase):
 
         self.assertEqual(0, result.returncode, result.stderr)
         payload = json.loads(result.stdout)
-        self.assertIn("systemMessage", payload)
-        self.assertIn("# Task Plan", payload["systemMessage"])
+        hook_output = payload["hookSpecificOutput"]
+        self.assertEqual("PreToolUse", hook_output["hookEventName"])
+        self.assertIn("# Task Plan", hook_output["additionalContext"])
+
+    def test_pre_tool_use_adapter_preserves_unicode_as_ascii_safe_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            root.joinpath("task_plan.md").write_text("# \u4efb\u52a1\u8ba1\u5212\n", encoding="utf-8")
+
+            result = self.run_python_hook(
+                "pre_tool_use.py",
+                {"cwd": str(root), "tool_input": {"command": "pwd"}},
+                root,
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertTrue(result.stdout.isascii())
+        payload = json.loads(result.stdout)
+        self.assertIn("\u4efb\u52a1\u8ba1\u5212", payload["hookSpecificOutput"]["additionalContext"])
 
     def test_post_tool_use_adapter_emits_progress_reminder(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -240,9 +281,45 @@ class CodexHooksTests(unittest.TestCase):
                     for bad in ("$HOME", "2>/dev/null", "|| true", "python3 "):
                         self.assertNotIn(bad, cw, f"{event} commandWindows still contains POSIX-ism {bad!r}")
 
+    def test_adapter_uses_explicit_utf8_for_shell_output(self) -> None:
+        sys.path.insert(0, str(HOOKS_DIR))
+        try:
+            import codex_hook_adapter as adapter
+
+            completed = subprocess.CompletedProcess(["sh"], 0, "ok\n", "")
+            with mock.patch.object(adapter, "_windows_git_bash", return_value=("sh", [])), mock.patch.object(
+                adapter.subprocess, "run", return_value=completed
+            ) as run:
+                stdout, stderr = adapter.run_shell_script("user-prompt-submit.sh", Path.cwd())
+        finally:
+            sys.path.pop(0)
+
+        self.assertEqual("ok", stdout)
+        self.assertEqual("", stderr)
+        self.assertEqual("utf-8", run.call_args.kwargs["encoding"])
+        self.assertEqual("replace", run.call_args.kwargs["errors"])
+
+    def test_emit_json_is_ascii_safe_and_round_trips_unicode(self) -> None:
+        sys.path.insert(0, str(HOOKS_DIR))
+        try:
+            import codex_hook_adapter as adapter
+
+            buffer = io.BytesIO()
+            stream = io.TextIOWrapper(buffer, encoding="ascii")
+            with mock.patch.object(adapter.sys, "stdout", stream):
+                adapter.emit_json({"message": "\u4e2d\u6587"})
+                stream.flush()
+            raw = buffer.getvalue().decode("ascii")
+            stream.detach()
+        finally:
+            sys.path.pop(0)
+
+        self.assertTrue(raw.isascii())
+        self.assertEqual("\u4e2d\u6587", json.loads(raw)["message"])
+
     @unittest.skipUnless(os.name == "nt", "commandWindows path is Windows-only")
-    def test_run_sh_front_door_injects_plan_on_windows(self) -> None:
-        """End-to-end Windows path: run_sh.py -> adapter git-bash resolver -> .sh."""
+    def test_run_sh_front_door_serializes_shell_events_on_windows(self) -> None:
+        """End-to-end Windows path emits event-appropriate Codex JSON."""
         sys.path.insert(0, str(HOOKS_DIR))
         try:
             import codex_hook_adapter as adapter
@@ -255,13 +332,30 @@ class CodexHooksTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
             root.joinpath("task_plan.md").write_text(
-                "# Task Plan\n\n## Goal\nWindows hook parity\n", encoding="utf-8"
+                "# \u4efb\u52a1\u8ba1\u5212\n\n## Goal\nWindows hook parity\n", encoding="utf-8"
             )
-            result = self.run_windows_front_door("user-prompt-submit.sh", {"cwd": str(root)}, root)
+            root.joinpath("progress.md").write_text("# Progress\n", encoding="utf-8")
 
-        self.assertEqual(0, result.returncode, result.stderr)
-        self.assertIn("ACTIVE PLAN", result.stdout)
-        self.assertIn("Windows hook parity", result.stdout)
+            user_prompt = self.run_windows_front_door("user-prompt-submit.sh", {"cwd": str(root)}, root)
+            session_start = self.run_windows_front_door("session-start.sh", {"cwd": str(root)}, root)
+            pre_compact = self.run_windows_front_door("pre-compact.sh", {"cwd": str(root)}, root)
+
+        for result in (user_prompt, session_start, pre_compact):
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertTrue(result.stdout.isascii())
+
+        user_payload = json.loads(user_prompt.stdout)
+        self.assertEqual("UserPromptSubmit", user_payload["hookSpecificOutput"]["hookEventName"])
+        self.assertIn("Windows hook parity", user_payload["hookSpecificOutput"]["additionalContext"])
+        self.assertIn("\u4efb\u52a1\u8ba1\u5212", user_payload["hookSpecificOutput"]["additionalContext"])
+
+        session_payload = json.loads(session_start.stdout)
+        self.assertEqual("SessionStart", session_payload["hookSpecificOutput"]["hookEventName"])
+        self.assertIn("Windows hook parity", session_payload["hookSpecificOutput"]["additionalContext"])
+
+        compact_payload = json.loads(pre_compact.stdout)
+        self.assertTrue(compact_payload["continue"])
+        self.assertIn("PreCompact", compact_payload["systemMessage"])
 
 
 if __name__ == "__main__":

--- a/tests/test_codex_session_isolation.py
+++ b/tests/test_codex_session_isolation.py
@@ -121,11 +121,7 @@ class CodexSessionIsolationTests(unittest.TestCase):
             payload = {"cwd": str(root), "session_id": "sess-B"}
             result = self.run_python_hook("pre_tool_use.py", payload, root)
             self.assertEqual(0, result.returncode, result.stderr)
-            # No systemMessage payload should be emitted
-            stdout = result.stdout.strip()
-            if stdout:
-                emitted = json.loads(stdout)
-                self.assertNotIn("systemMessage", emitted)
+            self.assertEqual("", result.stdout.strip())
 
     def test_stop_does_not_block_unattached_session(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_hook_resolver_integration.py
+++ b/tests/test_hook_resolver_integration.py
@@ -8,7 +8,9 @@ by exercising the full hook→resolver→plan-file chain.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -18,13 +20,36 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 HOOKS_DIR = REPO_ROOT / ".codex" / "hooks"
 
 
-def run_hook(script: str, cwd: Path, env_extra: dict | None = None) -> subprocess.CompletedProcess[str]:
+def shell_and_env() -> tuple[str, dict[str, str]]:
     env = os.environ.copy()
+    if os.name != "nt":
+        shell = shutil.which("sh")
+        if shell is None:
+            raise unittest.SkipTest("POSIX sh is unavailable")
+        return shell, env
+
+    sys.path.insert(0, str(HOOKS_DIR))
+    try:
+        import codex_hook_adapter as adapter
+
+        shell, extra_path_dirs = adapter._windows_git_bash()
+    finally:
+        sys.path.pop(0)
+    if shell is None:
+        raise unittest.SkipTest("Git for Windows sh.exe is unavailable")
+    if extra_path_dirs:
+        env["PATH"] = os.pathsep.join([*extra_path_dirs, env.get("PATH", "")])
+    env.setdefault("PYTHON_BIN", sys.executable)
+    return shell, env
+
+
+def run_hook(script: str, cwd: Path, env_extra: dict | None = None) -> subprocess.CompletedProcess[str]:
+    shell, env = shell_and_env()
     env.pop("PLAN_ID", None)
     if env_extra:
         env.update(env_extra)
     return subprocess.run(
-        ["sh", str(HOOKS_DIR / script)],
+        [shell, str(HOOKS_DIR / script)],
         cwd=str(cwd),
         text=True,
         encoding="utf-8",
@@ -45,6 +70,12 @@ def write_plan_in_dir(plan_dir: Path, goal: str = "Ship the feature") -> None:
 
 
 class HookResolverIntegrationTests(unittest.TestCase):
+
+    def test_global_resolver_is_a_thin_canonical_forwarder(self) -> None:
+        resolver = (HOOKS_DIR / "resolve-plan-dir.sh").read_text(encoding="utf-8")
+        self.assertIn("../skills/planning-with-files/scripts/resolve-plan-dir.sh", resolver)
+        self.assertIn('exec sh "${CANONICAL_RESOLVER}" "$@"', resolver)
+        self.assertNotIn("resolve_latest_dir()", resolver)
 
     # ------------------------------------------------------------------
     # user-prompt-submit.sh
@@ -93,6 +124,84 @@ class HookResolverIntegrationTests(unittest.TestCase):
             self.assertEqual(0, result.returncode, result.stderr)
             self.assertIn("Task A goal", result.stdout)
             self.assertNotIn("Task B goal", result.stdout)
+
+    def test_user_prompt_submit_accepts_utf8_bom_active_pointer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            safe = root / ".planning" / "safe"
+            write_plan_in_dir(safe, goal="BOM-safe goal")
+            decoy = root / ".planning" / "newer-decoy"
+            write_plan_in_dir(decoy, goal="Newest fallback goal")
+            # If BOM stripping regresses, newest-dir fallback must select the
+            # decoy and make this test fail instead of masking the bug.
+            os.utime(safe, (100, 100))
+            os.utime(decoy, (200, 200))
+            (root / ".planning" / ".active_plan").write_bytes(b"\xef\xbb\xbfsafe\n")
+
+            result = run_hook("user-prompt-submit.sh", root)
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertIn("BOM-safe goal", result.stdout)
+            self.assertNotIn("Newest fallback goal", result.stdout)
+
+    def test_user_prompt_submit_rejects_traversal_plan_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            write_plan_in_dir(root / ".planning" / "safe", goal="Workspace plan")
+            write_plan_in_dir(root / "outside", goal="Escaped plan")
+            (root / ".planning" / ".active_plan").write_text("safe\n", encoding="utf-8")
+
+            result = run_hook(
+                "user-prompt-submit.sh",
+                root,
+                env_extra={"PLAN_ID": "../outside"},
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertIn("Workspace plan", result.stdout)
+            self.assertNotIn("Escaped plan", result.stdout)
+
+    def test_user_prompt_submit_rejects_external_symlink_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as outside_tmp:
+            root = Path(tmp)
+            safe = root / ".planning" / "safe"
+            outside = Path(outside_tmp) / "outside"
+            write_plan_in_dir(safe, goal="Workspace plan")
+            write_plan_in_dir(outside, goal="Escaped plan")
+            (root / ".planning" / ".active_plan").write_text("safe\n", encoding="utf-8")
+            escape = root / ".planning" / "escape"
+            try:
+                try:
+                    escape.symlink_to(outside, target_is_directory=True)
+                except OSError as symlink_error:
+                    if os.name != "nt":
+                        self.skipTest(f"directory symlinks are unavailable: {symlink_error}")
+                    junction = subprocess.run(
+                        ["cmd", "/d", "/c", "mklink", "/J", str(escape), str(outside)],
+                        text=True,
+                        encoding="utf-8",
+                        errors="replace",
+                        capture_output=True,
+                        check=False,
+                    )
+                    if junction.returncode != 0:
+                        self.skipTest("directory symlinks and junctions are unavailable")
+
+                result = run_hook(
+                    "user-prompt-submit.sh",
+                    root,
+                    env_extra={"PLAN_ID": "escape"},
+                )
+
+                self.assertEqual(0, result.returncode, result.stderr)
+                self.assertIn("Workspace plan", result.stdout)
+                self.assertNotIn("Escaped plan", result.stdout)
+            finally:
+                if escape.is_symlink():
+                    escape.unlink()
+                elif os.name == "nt" and escape.exists():
+                    # os.rmdir removes the junction itself, never its target.
+                    os.rmdir(escape)
 
     # ------------------------------------------------------------------
     # pre-tool-use.sh

--- a/tests/test_session_catchup.py
+++ b/tests/test_session_catchup.py
@@ -3,6 +3,8 @@ import io
 import json
 import os
 import shutil
+import subprocess
+import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
@@ -237,6 +239,50 @@ class SessionCatchupCodexTests(unittest.TestCase):
         self.assertIn("Runtime: codex", output)
         self.assertIn("Last planning update: task_plan.md", output)
         self.assertIn("CODEX: Codex summary after planning update", output)
+
+    def test_codex_cli_prints_unicode_when_parent_requests_cp1252(self):
+        for filename in self.module.PLANNING_FILES:
+            (self.project_dir / filename).write_text("# test\n", encoding="utf-8")
+        self.write_codex_session(
+            "rollout-2026-04-07T00-00-00-unicode-thread.jsonl",
+            records=[
+                {
+                    "timestamp": "2026-04-07T00:00:02.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "patch_apply_end",
+                        "success": True,
+                        "changes": {"task_plan.md": {"operation": "modified"}},
+                    },
+                },
+                {
+                    "timestamp": "2026-04-07T00:00:03.000Z",
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": "继续完成中文计划"},
+                        ],
+                    },
+                },
+            ],
+        )
+        env = os.environ.copy()
+        env["CODEX_SESSIONS_DIR"] = str(self.sessions_dir)
+        env["PYTHONIOENCODING"] = "cp1252"
+        env.pop("CODEX_THREAD_ID", None)
+
+        result = subprocess.run(
+            [sys.executable, str(self.codex_script), self.project_path],
+            capture_output=True,
+            encoding="utf-8",
+            env=env,
+            check=False,
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("继续完成中文计划", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_set_active_plan.py
+++ b/tests/test_set_active_plan.py
@@ -6,6 +6,8 @@ init-session.sh for parallel multi-task workflows (#148).
 """
 from __future__ import annotations
 
+import os
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -14,6 +16,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SET_ACTIVE_SH = REPO_ROOT / "scripts" / "set-active-plan.sh"
+SET_ACTIVE_PS1 = REPO_ROOT / "scripts" / "set-active-plan.ps1"
+RESOLVE_SH = REPO_ROOT / "scripts" / "resolve-plan-dir.sh"
+POWERSHELL = shutil.which("powershell.exe") or shutil.which("powershell")
+SH = shutil.which("sh")
 
 
 def run_set_active(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -31,6 +37,68 @@ class SetActivePlanTests(unittest.TestCase):
 
     def test_script_exists(self) -> None:
         self.assertTrue(SET_ACTIVE_SH.exists(), "scripts/set-active-plan.sh missing")
+
+    def test_powershell_script_is_ascii_safe_for_windows_powershell_5(self) -> None:
+        """UTF-8 without a BOM must not become invalid Windows PowerShell syntax."""
+        self.assertTrue(SET_ACTIVE_PS1.exists(), "scripts/set-active-plan.ps1 missing")
+        try:
+            SET_ACTIVE_PS1.read_bytes().decode("ascii")
+        except UnicodeDecodeError as error:
+            self.fail(
+                "set-active-plan.ps1 must stay ASCII-safe because Windows PowerShell 5.1 "
+                f"can decode BOM-less UTF-8 as the active ANSI code page: {error}"
+            )
+
+    @unittest.skipUnless(
+        POWERSHELL and SH,
+        "requires Windows PowerShell and sh for the cross-shell regression test",
+    )
+    def test_powershell_pointer_is_utf8_without_bom_and_resolves(self) -> None:
+        """The PS 5.1 writer must not add a BOM that the shell resolver rejects."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            selected = root / ".planning" / "selected"
+            newest = root / ".planning" / "newest"
+            selected.mkdir(parents=True)
+            newest.mkdir(parents=True)
+            (selected / "task_plan.md").write_text("# Selected\n", encoding="utf-8")
+            (newest / "task_plan.md").write_text("# Newest\n", encoding="utf-8")
+            selected_mtime = selected.stat().st_mtime
+            os.utime(newest, (selected_mtime + 10, selected_mtime + 10))
+
+            written = subprocess.run(
+                [
+                    POWERSHELL,
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(SET_ACTIVE_PS1),
+                    "selected",
+                ],
+                cwd=str(root),
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(0, written.returncode, written.stderr)
+            self.assertEqual(
+                b"selected",
+                (root / ".planning" / ".active_plan").read_bytes(),
+            )
+
+            resolved = subprocess.run(
+                [SH, str(RESOLVE_SH)],
+                cwd=str(root),
+                text=True,
+                encoding="utf-8",
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(0, resolved.returncode, resolved.stderr)
+            self.assertTrue(resolved.stdout.strip().endswith("selected"))
 
     def test_no_args_no_active_plan_prints_none(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- serialize `SessionStart`, `UserPromptSubmit`, and `PreCompact` with supported Codex JSON shapes
- make Windows shell output explicitly UTF-8 and JSON safe across Windows code pages
- inject `PreToolUse` plan text through model-visible `additionalContext`
- resolve scoped plans for `PermissionRequest`
- run `SessionStart` after `clear` and `compact`
- keep PowerShell-created `.active_plan` pointers ASCII-safe and UTF-8 without BOM
- add regression coverage for event schemas, Unicode, scoped plans, session isolation, and PowerShell-to-Bash plan resolution

## Root cause

The v3.4.1 Windows launcher forwarded plain-text hook output that Codex could reject as JSON, relied on Windows default encodings, and used UI-only `systemMessage` for pre-tool context. Windows PowerShell 5.1 could also misparse the helper source or add a BOM that made the shell resolver ignore the selected plan.

## Verification

- `python -m pytest tests/test_set_active_plan.py tests/test_canonical_script_sync.py -q`: 10 passed
- `python -m pytest tests/ -q`: 208 passed, 5 skipped, 36 subtests passed

Closes #204