### PR TITLE
docs: add memgraph to Used in the Wild

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ One hook fire measures 289ms wall-clock since the v3.6.0 optimization, down from
 | [cooragent/ClarityFinance](https://github.com/cooragent/ClarityFinance) | AI finance agent framework, Planning-with-Files approach directly credited |
 | [oeftimie/vv-claude-harness](https://github.com/oeftimie/vv-claude-harness) | Claude Code harness built on Manus-style persistent markdown planning |
 | [jessepwj/CCteam-creator](https://github.com/jessepwj/CCteam-creator) | Multi-agent team orchestration skill using file-based planning |
+| [javimosch/memgraph](https://github.com/javimosch/memgraph) | Knowledge graph CLI that indexes task_plan.md/findings.md/progress.md as graph nodes; `recommend --include-plans` returns past plans alongside skill recommendations for cross-session memory |
 
 ### Skill Registries & Hubs
 


### PR DESCRIPTION
## What

Adds [memgraph](https://github.com/javimosch/memgraph) to the "Used in the Wild" table.

## Why

memgraph is a knowledge graph CLI for AI coding agents. It indexes `task_plan.md`, `findings.md`, and `progress.md` as graph nodes (`type: "plan"`), so `memgraph recommend --include-plans` returns past plans alongside skill recommendations.

This turns planning-with-files from a single-session tool into cross-session memory: "last time you fixed a websocket bug, you used `audit-website` and here is what your `task_plan.md` said worked and what failed."

The integration is one of six built-in patterns in memgraph's plan discovery system (the others are `TODO.md`, `PLAN.md`, `ROADMAP.md`, `docs/plans/*.md`, and an auto-detect heuristic for any `.md` with phase/checkbox structure). planning-with-files is the first-class citizen, not a special case.

## How it works

```
planning-with-files          memgraph
task_plan.md        ---->   type: "plan" node in graph
findings.md         ---->   content extracted from findings
progress.md         ---->   status inferred from checkboxes

memgraph recommend "fix websocket" --include-plans
  -> returns audit-website skill (score 215)
  -> returns past plan "Fix websocket auth bypass" (score 227)
```

Users run `memgraph graph-from-dir --include-plans` to index both skills and plans, then `memgraph recommend "<task>" --include-plans` to get both back.

## Cross-link

memgraph's README now has a dedicated Integrations section featuring planning-with-files with a star badge, architecture diagram, and usage examples.

No code changes to planning-with-files itself. Just a README entry.