### PR TITLE
fix: ignore unstructured plans in Copilot PowerShell stop hook

### DIFF
--- a/.github/hooks/scripts/agent-stop.ps1
+++ b/.github/hooks/scripts/agent-stop.ps1
@@ -32,6 +32,11 @@ if ($COMPLETE -eq 0 -and $IN_PROGRESS -eq 0 -and $PENDING -eq 0) {
     $PENDING = ([regex]::Matches($content, "\[pending\]")).Count
 }
 
+if ($TOTAL -eq 0) {
+    Write-Output '{}'
+    exit 0
+}
+
 if ($COMPLETE -eq $TOTAL -and $TOTAL -gt 0) {
     $msg = "[planning-with-files] ALL PHASES COMPLETE ($COMPLETE/$TOTAL). If the user has additional work, add new phases to task_plan.md before starting."
     $output = @{

--- a/tests/test_copilot_agent_stop.py
+++ b/tests/test_copilot_agent_stop.py
@@ -1,0 +1,55 @@
+"""Behavior tests for the GitHub Copilot AgentStop hooks."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENT_STOP_PS1 = REPO_ROOT / ".github" / "hooks" / "scripts" / "agent-stop.ps1"
+POWERSHELL = (
+    shutil.which("pwsh")
+    or shutil.which("powershell.exe")
+    or shutil.which("powershell")
+)
+
+
+@unittest.skipUnless(POWERSHELL, "PowerShell is not available")
+class CopilotAgentStopPowerShellTests(unittest.TestCase):
+    def test_unstructured_plan_emits_empty_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = Path(tmp)
+            (cwd / "task_plan.md").write_text(
+                "# Notes\n\nThis file has no phase structure.\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    str(POWERSHELL),
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(AGENT_STOP_PS1),
+                ],
+                cwd=cwd,
+                input="{}",
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertEqual({}, json.loads(result.stdout.lstrip("\ufeff")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Added a zero-phase guard to the GitHub Copilot PowerShell AgentStop hook, matching the existing shell behavior.
- Added a behavior test that executes the real PowerShell script against an unstructured task_plan.md fixture.

## Why

A task_plan.md without any ### Phase headings produced a misleading "Task incomplete (0/0 phases done)" message on Windows. The shell hook received this guard in the issue #191 fix, but the PowerShell counterpart was omitted.

## How tested

- python -m pytest tests/test_copilot_agent_stop.py -q (1 passed)
- python -m pytest tests/ -q (430 passed, 6 skipped, 474 subtests passed)
- npm test in the Pi extension (48 passed)

## Known limitations

The PowerShell behavior test skips on hosts without a PowerShell executable. The repository Windows CI job provides Windows PowerShell and exercises it.