### PR TITLE
fix: honor PLANNING_DISABLED in GitHub Copilot hooks

### DIFF
--- a/.github/hooks/scripts/agent-stop.ps1
+++ b/.github/hooks/scripts/agent-stop.ps1
@@ -8,6 +8,11 @@ $OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 $InputData = [Console]::In.ReadToEnd()
 
+if ($env:PLANNING_DISABLED -eq '1') {
+    Write-Output '{}'
+    exit 0
+}
+
 $PlanFile = "task_plan.md"
 
 if (-not (Test-Path $PlanFile)) {

--- a/.github/hooks/scripts/agent-stop.sh
+++ b/.github/hooks/scripts/agent-stop.sh
@@ -7,6 +7,8 @@
 # Read stdin (required — Copilot pipes JSON to stdin)
 INPUT=$(cat)
 
+[ "${PLANNING_DISABLED:-}" = "1" ] && { echo '{}'; exit 0; }
+
 PLAN_FILE="task_plan.md"
 
 if [ ! -f "$PLAN_FILE" ]; then

--- a/.github/hooks/scripts/error-occurred.ps1
+++ b/.github/hooks/scripts/error-occurred.ps1
@@ -1,6 +1,11 @@
 # planning-with-files: Error hook for GitHub Copilot (Windows PowerShell)
 # Logs errors to task_plan.md when the agent encounters an error.
 
+if ($env:PLANNING_DISABLED -eq '1') {
+    Write-Output '{}'
+    exit 0
+}
+
 $planFile = "task_plan.md"
 
 if (-not (Test-Path $planFile)) {

--- a/.github/hooks/scripts/error-occurred.sh
+++ b/.github/hooks/scripts/error-occurred.sh
@@ -6,6 +6,8 @@
 # Read stdin (required — Copilot pipes JSON to stdin)
 INPUT=$(cat)
 
+[ "${PLANNING_DISABLED:-}" = "1" ] && { echo '{}'; exit 0; }
+
 PLAN_FILE="task_plan.md"
 
 if [ ! -f "$PLAN_FILE" ]; then

--- a/.github/hooks/scripts/post-tool-use.ps1
+++ b/.github/hooks/scripts/post-tool-use.ps1
@@ -7,6 +7,11 @@ $OutputEncoding = [System.Text.Encoding]::UTF8
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $InputData = [Console]::In.ReadToEnd()
 
+if ($env:PLANNING_DISABLED -eq '1') {
+    Write-Output '{}'
+    exit 0
+}
+
 $output = @{
     hookSpecificOutput = @{
         hookEventName = "PostToolUse"

--- a/.github/hooks/scripts/post-tool-use.sh
+++ b/.github/hooks/scripts/post-tool-use.sh
@@ -6,5 +6,7 @@
 # Read stdin (required — Copilot pipes JSON to stdin)
 INPUT=$(cat)
 
+[ "${PLANNING_DISABLED:-}" = "1" ] && { echo '{}'; exit 0; }
+
 echo '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"[planning-with-files] Update progress.md with what you just did. If a phase is now complete, update task_plan.md status."}}'
 exit 0

--- a/.github/hooks/scripts/pre-tool-use.ps1
+++ b/.github/hooks/scripts/pre-tool-use.ps1
@@ -8,6 +8,11 @@ $OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 $InputData = [Console]::In.ReadToEnd()
 
+if ($env:PLANNING_DISABLED -eq '1') {
+    Write-Output '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+    exit 0
+}
+
 $PlanFile = "task_plan.md"
 
 if (-not (Test-Path $PlanFile)) {

--- a/.github/hooks/scripts/pre-tool-use.sh
+++ b/.github/hooks/scripts/pre-tool-use.sh
@@ -7,6 +7,11 @@
 # Read stdin (required — Copilot pipes JSON to stdin)
 INPUT=$(cat)
 
+[ "${PLANNING_DISABLED:-}" = "1" ] && {
+    echo '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow"}}'
+    exit 0
+}
+
 PLAN_FILE="task_plan.md"
 
 if [ ! -f "$PLAN_FILE" ]; then

--- a/.github/hooks/scripts/session-start.ps1
+++ b/.github/hooks/scripts/session-start.ps1
@@ -8,6 +8,11 @@ $OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
 $InputData = [Console]::In.ReadToEnd()
 
+if ($env:PLANNING_DISABLED -eq '1') {
+    Write-Output '{}'
+    exit 0
+}
+
 $PlanFile = "task_plan.md"
 $SkillDir = ".github/skills/planning-with-files"
 

--- a/.github/hooks/scripts/session-start.sh
+++ b/.github/hooks/scripts/session-start.sh
@@ -7,6 +7,8 @@
 # Read stdin (required — Copilot pipes JSON to stdin)
 INPUT=$(cat)
 
+[ "${PLANNING_DISABLED:-}" = "1" ] && { echo '{}'; exit 0; }
+
 PLAN_FILE="task_plan.md"
 SKILL_DIR=".github/skills/planning-with-files"
 PYTHON=""

--- a/tests/test_planning_disabled_optout.py
+++ b/tests/test_planning_disabled_optout.py
@@ -8,7 +8,9 @@ attachment path the issue reports) with and without the env var.
 """
 from __future__ import annotations
 
+import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -17,12 +19,20 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 CODEX_HOOKS = REPO / ".codex" / "hooks"
+COPILOT_HOOKS = REPO / ".github" / "hooks" / "scripts"
 SCRIPTS = REPO / "scripts"
+POWERSHELL = (
+    shutil.which("pwsh")
+    or shutil.which("powershell.exe")
+    or shutil.which("powershell")
+)
 
 PLAN = "# Test Plan\n### Phase 1: something\n**Status:** in_progress\n"
 
 
-def run_sh(script: Path, cwd: Path, disabled: bool) -> subprocess.CompletedProcess:
+def run_sh(
+    script: Path, cwd: Path, disabled: bool, input_data: str = ""
+) -> subprocess.CompletedProcess:
     env = dict(os.environ)
     env.pop("PLANNING_DISABLED", None)
     if disabled:
@@ -31,6 +41,34 @@ def run_sh(script: Path, cwd: Path, disabled: bool) -> subprocess.CompletedProce
         ["sh", str(script)],
         cwd=str(cwd),
         env=env,
+        input=input_data,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=60,
+    )
+
+
+def run_powershell(
+    script: Path, cwd: Path, disabled: bool
+) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("PLANNING_DISABLED", None)
+    if disabled:
+        env["PLANNING_DISABLED"] = "1"
+    return subprocess.run(
+        [
+            str(POWERSHELL),
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script),
+        ],
+        cwd=str(cwd),
+        env=env,
+        input='{"error":{"message":"fixture failure"}}',
         capture_output=True,
         text=True,
         encoding="utf-8",
@@ -137,6 +175,30 @@ class PlanningDisabledOptOutTests(unittest.TestCase):
             (self.cwd / "progress.md").read_text(encoding="utf-8"), "progress line\n"
         )
 
+    def test_copilot_shell_hooks_skip_context_when_disabled(self) -> None:
+        for name in (
+            "session-start.sh",
+            "pre-tool-use.sh",
+            "post-tool-use.sh",
+            "agent-stop.sh",
+            "error-occurred.sh",
+        ):
+            with self.subTest(hook=name):
+                result = run_sh(
+                    COPILOT_HOOKS / name,
+                    self.cwd,
+                    disabled=True,
+                    input_data='{"error":{"message":"fixture failure"}}',
+                )
+                self.assertEqual(0, result.returncode, result.stderr)
+                payload = json.loads(result.stdout.lstrip("\ufeff"))
+                hook_output = payload.get("hookSpecificOutput", {})
+                self.assertNotIn("additionalContext", hook_output)
+                if name == "pre-tool-use.sh":
+                    self.assertEqual("allow", hook_output.get("permissionDecision"))
+                else:
+                    self.assertEqual({}, payload)
+
     # --- Every distributed copy carries the guard ---
 
     def test_all_check_complete_copies_carry_the_guard(self) -> None:
@@ -153,6 +215,39 @@ class PlanningDisabledOptOutTests(unittest.TestCase):
                 text,
                 f"missing opt-out guard: {copy.relative_to(REPO)}",
             )
+
+
+@unittest.skipUnless(POWERSHELL, "PowerShell is not available")
+class CopilotPowerShellPlanningDisabledTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.cwd = Path(self._tmp.name)
+        (self.cwd / "task_plan.md").write_text(PLAN, encoding="utf-8")
+        (self.cwd / "progress.md").write_text("progress line\n", encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_copilot_powershell_hooks_skip_context_when_disabled(self) -> None:
+        for name in (
+            "session-start.ps1",
+            "pre-tool-use.ps1",
+            "post-tool-use.ps1",
+            "agent-stop.ps1",
+            "error-occurred.ps1",
+        ):
+            with self.subTest(hook=name):
+                result = run_powershell(
+                    COPILOT_HOOKS / name, self.cwd, disabled=True
+                )
+                self.assertEqual(0, result.returncode, result.stderr)
+                payload = json.loads(result.stdout.lstrip("\ufeff"))
+                hook_output = payload.get("hookSpecificOutput", {})
+                self.assertNotIn("additionalContext", hook_output)
+                if name == "pre-tool-use.ps1":
+                    self.assertEqual("allow", hook_output.get("permissionDecision"))
+                else:
+                    self.assertEqual({}, payload)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Added PLANNING_DISABLED=1 guards to all GitHub Copilot shell and PowerShell hook entry points.
- Kept the PreToolUse permission decision as allow while suppressing planning context.
- Extended the existing opt-out regression suite to execute all ten Copilot hooks.

## Why

The documented per-invocation opt-out covered the canonical and Codex hook routes, but the GitHub Copilot integration still read task_plan.md and emitted planning reminders when PLANNING_DISABLED=1 was set. This could attach an unrelated plan to a one-shot Copilot task sharing the same working directory.

## How tested

- python -m pytest tests/test_planning_disabled_optout.py -q (14 passed, 10 subtests passed)
- python -m pytest tests/ -q (431 passed, 6 skipped, 484 subtests passed)
- npm test in the Pi extension (48 passed)
- sh -n .github/hooks/scripts/*.sh

## Known limitations

Only the exact value PLANNING_DISABLED=1 disables hooks, matching the existing repository contract. Other values preserve current behavior.