### PR TITLE
test: run Hermes probe with the active Python interpreter

### DIFF
--- a/tests/test_injection_determinism.py
+++ b/tests/test_injection_determinism.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -373,7 +374,7 @@ class NoRawWallClockTests(unittest.TestCase):
         # so it never received the v2.40 sed pass. Same contract, same fixture.
         # Its package directory name contains a dash, so it cannot be imported
         # by name; load it under a synthetic package instead.
-        result = self._run(["python", "-c", _HERMES_PROBE])
+        result = self._run([sys.executable, "-c", _HERMES_PROBE])
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertIn("ACTIVE PLAN", result.stdout)
         self._assert_normalized(result.stdout, ".hermes/plugins/planning-with-files")


### PR DESCRIPTION
## What changed

- Changed the Hermes injection determinism probe to launch with sys.executable.
- Kept the probe and all assertions unchanged.

## Why

The test suite can be started successfully with python3 on systems that do not provide a python command alias, including a default macOS setup. The Hermes probe then failed with FileNotFoundError because it hard-coded python instead of reusing the active test interpreter.

## How tested

- python3 -m pytest tests/test_injection_determinism.py::NoRawWallClockTests::test_hermes_adapter_normalizes_wall_clock -q (1 passed with no python alias on PATH)
- python3 -m pytest tests/ -q (408 passed, 27 skipped, 474 subtests passed)
- npm test in the Pi extension (48 passed)

## Known limitations

This is a test portability change only. It does not change the Hermes adapter or runtime interpreter requirements.