### PR TITLE
fix: feed the Copilot error hook over a pipe so dash can parse it

### DIFF
--- a/.github/hooks/scripts/error-occurred.sh
+++ b/.github/hooks/scripts/error-occurred.sh
@@ -21,7 +21,7 @@ for _p in /usr/bin/python3 /usr/local/bin/python3 /opt/homebrew/bin/python3; do
     [ -x "$_p" ] && { PYTHON="$_p"; break; }
 done
 [ -z "$PYTHON" ] && PYTHON=$(command -v python3 2>/dev/null || command -v python 2>/dev/null)
-ERROR_MSG=$($PYTHON -c "
+ERROR_MSG=$(printf '%s\n' "$INPUT" | $PYTHON -c "
 import sys, json
 try:
     data = json.load(sys.stdin)
@@ -29,11 +29,11 @@ try:
     print(msg[:200])
 except:
     print('')
-" <<< "$INPUT" 2>/dev/null || echo "")
+" 2>/dev/null || echo "")
 
 if [ -n "$ERROR_MSG" ]; then
     CONTEXT="[planning-with-files] Error detected: ${ERROR_MSG}. Log this error in task_plan.md under Errors Encountered with the attempt number and resolution."
-    ESCAPED=$($PYTHON -c "import sys,json; print(json.dumps(sys.stdin.read(), ensure_ascii=False))" <<< "$CONTEXT" 2>/dev/null || echo "\"\"")
+    ESCAPED=$(printf '%s\n' "$CONTEXT" | $PYTHON -c "import sys,json; print(json.dumps(sys.stdin.read(), ensure_ascii=False))" 2>/dev/null || echo "\"\"")
     printf '%s\n' "{\"hookSpecificOutput\":{\"hookEventName\":\"ErrorOccurred\",\"additionalContext\":$ESCAPED}}"
 else
     echo '{}'


### PR DESCRIPTION
Master CI has failed on the ubuntu leg for five consecutive runs. `error-occurred.sh` uses `<<<` twice, dash has no here-string, and `tests/test_planning_disabled_optout.py` invokes hooks through `["sh", script]`, so the `#!/bin/bash` shebang never applies.

The four sibling hooks pipe with `echo`. I did not copy that form. Under dash, builtin `echo` expands backslash escapes, and `$INPUT` is raw JSON, so an escaped `\n` inside an error message becomes a control character that `json.load` rejects. Feeding the hook `{"error":{"message":"line1\nline2 boom"}}`, `printf '%s\n'` emits the ErrorOccurred context and `echo` emits `{}`. The echo form would trade a loud parse failure for a silent one, which is why 3c78c3c moved the output side off `echo`.

## How this was tested

Reproduced the ubuntu condition locally with a `sh -> /bin/dash` symlink ahead of `PATH`:

- before: `AssertionError: 0 != 2 : ... error-occurred.sh: 32: Syntax error: redirection unexpected` at test line 200, matching the CI log
- after: `401 passed, 43 skipped, 357 subtests passed` under dash, same totals under macOS `/bin/sh`
- reverting the change reproduces the failure, so the suite does exercise it
- `dash -n` passes on all five scripts in `.github/hooks/scripts/`; before this change the file was the only one of the five that failed

## Limitations

Copilot invokes the hook as `bash` per `.github/hooks/planning-with-files.json`, so no user was affected. This is a CI and portability fix.

The four `.gemini/hooks/*.sh` carry the same `<<<`. No test runs them through `sh`, and `.gemini/settings.json` invokes them by path so their shebang applies, which is why they are out of scope here. Worth a separate pass if you want the construct gone repo-wide.
