### PR TITLE
docs: name the skill directory in the skills-only install commands

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,7 +98,7 @@ If you only want the skill without the full plugin structure:
 
 ```bash
 git clone https://github.com/OthmanAdi/planning-with-files.git
-cp -r planning-with-files/skills/* ~/.claude/skills/
+cp -r planning-with-files/skills/planning-with-files ~/.claude/skills/
 ```
 
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -98,6 +98,7 @@ If you only want the skill without the full plugin structure:
 
 ```bash
 git clone https://github.com/OthmanAdi/planning-with-files.git
+mkdir -p ~/.claude/skills
 cp -r planning-with-files/skills/planning-with-files ~/.claude/skills/
 ```
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -35,7 +35,7 @@ git clone https://github.com/OthmanAdi/planning-with-files.git $env:USERPROFILE\
 
 ```powershell
 git clone https://github.com/OthmanAdi/planning-with-files.git
-Copy-Item -Recurse planning-with-files\skills\* $env:USERPROFILE\.claude\skills\
+Copy-Item -Recurse planning-with-files\skills\planning-with-files $env:USERPROFILE\.claude\skills\
 ```
 
 ---

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -35,6 +35,7 @@ git clone https://github.com/OthmanAdi/planning-with-files.git $env:USERPROFILE\
 
 ```powershell
 git clone https://github.com/OthmanAdi/planning-with-files.git
+New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.claude\skills" | Out-Null
 Copy-Item -Recurse planning-with-files\skills\planning-with-files $env:USERPROFILE\.claude\skills\
 ```
 

--- a/tests/test_plugin_skill_surface.py
+++ b/tests/test_plugin_skill_surface.py
@@ -46,6 +46,17 @@ EXPECTED_VARIANTS = {
 # has to start with the copy verb and the glob has to end the path segment.
 WHOLESALE_COPY_RE = re.compile(r"^\s*(?:cp\s|Copy-Item\b).*skills[\\/]\*(?:\s|$)")
 
+MANUAL_SKILL_COPY_COMMANDS = {
+    "docs/installation.md": (
+        "mkdir -p ~/.claude/skills",
+        "cp -r planning-with-files/skills/planning-with-files ~/.claude/skills/",
+    ),
+    "docs/windows.md": (
+        r'New-Item -ItemType Directory -Force -Path "$env:USERPROFILE\.claude\skills" | Out-Null',
+        r"Copy-Item -Recurse planning-with-files\skills\planning-with-files",
+    ),
+}
+
 
 def _plugin_registered_skills():
     """Directory names the Claude Code plugin scan registers (skills/*/SKILL.md)."""
@@ -54,16 +65,19 @@ def _plugin_registered_skills():
 
 def _tracked_markdown():
     """Every tracked .md file, via git; glob fallback for non-git checkouts."""
-    proc = subprocess.run(
-        ["git", "ls-files", "*.md"],
-        cwd=str(REPO_ROOT),
-        text=True,
-        encoding="utf-8",
-        capture_output=True,
-        check=False,
-    )
-    if proc.returncode == 0 and proc.stdout.strip():
-        return [REPO_ROOT / line for line in proc.stdout.splitlines() if line]
+    try:
+        proc = subprocess.run(
+            ["git", "-c", "core.quotepath=off", "ls-files", "--", "*.md"],
+            cwd=str(REPO_ROOT),
+            text=True,
+            encoding="utf-8",
+            capture_output=True,
+            check=False,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            return [REPO_ROOT / line for line in proc.stdout.splitlines() if line]
+    except OSError:
+        pass
     return [
         p
         for p in REPO_ROOT.rglob("*.md")
@@ -114,6 +128,19 @@ class PluginSkillSurfaceTests(unittest.TestCase):
             "commands look; name skills/planning-with-files instead: "
             + "; ".join(offenders),
         )
+
+    def test_manual_skill_copies_create_destination_first(self):
+        for rel, (create_destination, copy_skill) in MANUAL_SKILL_COPY_COMMANDS.items():
+            with self.subTest(doc=rel):
+                text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+                self.assertIn(create_destination, text)
+                self.assertIn(copy_skill, text)
+                self.assertLess(
+                    text.index(create_destination),
+                    text.index(copy_skill),
+                    "the skills directory must exist before the canonical skill "
+                    "directory is copied into it",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_plugin_skill_surface.py
+++ b/tests/test_plugin_skill_surface.py
@@ -14,9 +14,16 @@ a recursive scan of the repository, and still installs to
 
 This test fails if a variant is moved (or a new one is added) directly under
 `skills/`, which would silently put those descriptions back into every session.
+
+The extra depth also invalidated any install that copies `skills/*` wholesale
+into a skills directory: `i18n/` is not a skill, and the five variants land a
+level below where the loader and the `/plan-<lang>` commands look for them.
+The last check below keeps that shape out of the shipped install docs.
 """
 from __future__ import annotations
 
+import re
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -34,9 +41,34 @@ EXPECTED_VARIANTS = {
 }
 
 
+# A copy command whose source is the whole skills/ directory. Prose that
+# mentions `skills/*/SKILL.md` (the plugin scan) must not match, so the line
+# has to start with the copy verb and the glob has to end the path segment.
+WHOLESALE_COPY_RE = re.compile(r"^\s*(?:cp\s|Copy-Item\b).*skills[\\/]\*(?:\s|$)")
+
+
 def _plugin_registered_skills():
     """Directory names the Claude Code plugin scan registers (skills/*/SKILL.md)."""
     return {d.name for d in SKILLS_DIR.iterdir() if (d / "SKILL.md").is_file()}
+
+
+def _tracked_markdown():
+    """Every tracked .md file, via git; glob fallback for non-git checkouts."""
+    proc = subprocess.run(
+        ["git", "ls-files", "*.md"],
+        cwd=str(REPO_ROOT),
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode == 0 and proc.stdout.strip():
+        return [REPO_ROOT / line for line in proc.stdout.splitlines() if line]
+    return [
+        p
+        for p in REPO_ROOT.rglob("*.md")
+        if ".git" not in p.parts and "node_modules" not in p.parts
+    ]
 
 
 class PluginSkillSurfaceTests(unittest.TestCase):
@@ -60,6 +92,28 @@ class PluginSkillSurfaceTests(unittest.TestCase):
             with self.subTest(variant=name):
                 text = (I18N_DIR / name / "SKILL.md").read_text(encoding="utf-8")
                 self.assertIn(f"\nname: {name}\n", text)
+
+    def test_no_doc_installs_by_copying_the_skills_directory(self):
+        docs = _tracked_markdown()
+        self.assertTrue(docs, "no tracked .md files discovered")
+        offenders = []
+        for doc in docs:
+            if not doc.is_file():
+                continue
+            for lineno, line in enumerate(
+                doc.read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                if WHOLESALE_COPY_RE.match(line):
+                    rel = doc.relative_to(REPO_ROOT).as_posix()
+                    offenders.append(f"{rel}:{lineno}: {line.strip()}")
+        self.assertFalse(
+            offenders,
+            "install command copies the whole skills/ directory, which since "
+            "v3.11.0 also copies i18n/ (not a skill) and puts the five "
+            "variants a level below where the loader and the /plan-<lang> "
+            "commands look; name skills/planning-with-files instead: "
+            + "; ".join(offenders),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`docs/installation.md:101` and `docs/windows.md:38` are the only two install commands in the repo that copy `skills/*` instead of naming the skill directory. My #226 moved the language variants down a level, so that glob now also copies `skills/i18n/`, so `~/.claude/skills/i18n/` lands with no SKILL.md in it and the five translations sit at `~/.claude/skills/i18n/planning-with-files-de/`, one level below the path `/plan-de` probes first (`commands/plan-de.md:7`). Ran both forms into a scratch directory to confirm.

I did not add a second line copying `skills/i18n/*`, which would restore what the command used to install. `docs/languages.md:26` says installing English pulls in no translation, and dropping all six into `~/.claude/skills/` puts the five extra descriptions back into every session, which is the cost #226 removed on the plugin route. Section 4 of installation.md and `README.md:250` name `skills/planning-with-files`.

The guard went into `tests/test_plugin_skill_surface.py`, the file that owns the depth invariant. It matches lines beginning with `cp` or `Copy-Item` only, so prose about `skills/*/SKILL.md` does not trip it. Reverting either doc line fails it with both paths named.

Limitation: `docs/windows.md` carries no language-variant section, so a Windows reader on the skills-only route is not pointed at `npx skills add --skill`. Left alone rather than widened.

444 collected, 414 passed and 31 skipped locally; `sync-ide-folders.py --verify` clean.

