### PR TITLE
fix: make init help side-effect free

### DIFF
--- a/.agents/skills/planning-with-files/scripts/init-session.sh
+++ b/.agents/skills/planning-with-files/scripts/init-session.sh
@@ -24,6 +24,21 @@
 
 set -e
 
+usage() {
+    cat << 'EOF'
+Usage: init-session.sh [OPTIONS] [PROJECT NAME]
+
+Initialize task_plan.md, findings.md, and progress.md for a planning session.
+
+Options:
+  -t, --template TYPE  Use the default or analytics template.
+      --plan-dir       Create an isolated plan directory without a name.
+      --autonomous     Enable autonomous mode and plan attestation.
+      --gated          Enable autonomous mode with the completion gate.
+  -h, --help           Print this help and exit without changing files.
+EOF
+}
+
 TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
@@ -50,6 +65,10 @@ while [ $# -gt 0 ]; do
         --gated)
             MODE="gated"
             shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
             ;;
         *)
             if [ -z "$PROJECT_NAME" ]; then

--- a/.codebuddy/skills/planning-with-files/scripts/init-session.sh
+++ b/.codebuddy/skills/planning-with-files/scripts/init-session.sh
@@ -24,6 +24,21 @@
 
 set -e
 
+usage() {
+    cat << 'EOF'
+Usage: init-session.sh [OPTIONS] [PROJECT NAME]
+
+Initialize task_plan.md, findings.md, and progress.md for a planning session.
+
+Options:
+  -t, --template TYPE  Use the default or analytics template.
+      --plan-dir       Create an isolated plan directory without a name.
+      --autonomous     Enable autonomous mode and plan attestation.
+      --gated          Enable autonomous mode with the completion gate.
+  -h, --help           Print this help and exit without changing files.
+EOF
+}
+
 TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
@@ -50,6 +65,10 @@ while [ $# -gt 0 ]; do
         --gated)
             MODE="gated"
             shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
             ;;
         *)
             if [ -z "$PROJECT_NAME" ]; then

--- a/.codex/skills/planning-with-files/scripts/init-session.sh
+++ b/.codex/skills/planning-with-files/scripts/init-session.sh
@@ -24,6 +24,21 @@
 
 set -e
 
+usage() {
+    cat << 'EOF'
+Usage: init-session.sh [OPTIONS] [PROJECT NAME]
+
+Initialize task_plan.md, findings.md, and progress.md for a planning session.
+
+Options:
+  -t, --template TYPE  Use the default or analytics template.
+      --plan-dir       Create an isolated plan directory without a name.
+      --autonomous     Enable autonomous mode and plan attestation.
+      --gated          Enable autonomous mode with the completion gate.
+  -h, --help           Print this help and exit without changing files.
+EOF
+}
+
 TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
@@ -50,6 +65,10 @@ while [ $# -gt 0 ]; do
         --gated)
             MODE="gated"
             shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
             ;;
         *)
             if [ -z "$PROJECT_NAME" ]; then

--- a/.continue/skills/planning-with-files/scripts/init-session.sh
+++ b/.continue/skills/planning-with-files/scripts/init-session.sh
@@ -24,6 +24,21 @@
 
 set -e
 
+usage() {
+    cat << 'EOF'
+Usage: init-session.sh [OPTIONS] [PROJECT NAME]
+
+Initialize task_plan.md, findings.md, and progress.md for a planning session.
+
+Options:
+  -t, --template TYPE  Use the default or analytics template.
+      --plan-dir       Create an isolated plan directory without a name.
+      --autonomous     Enable autonomous mode and plan attestation.
+      --gated          Enable autonomous mode with the completion gate.
+  -h, --help           Print this help and exit without changing files.
+EOF
+}
+
 TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
@@ -50,6 +65,10 @@ while [ $# -gt 0 ]; do
         --gated)
             MODE="gated"
             shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
             ;;
         *)
             if [ -z "$PROJECT_NAME" ]; then

--- a/.cursor/skills/planning-with-files/scripts/init-session.sh
+++ b/.cursor/skills/planning-with-files/scripts/init-session.sh
@@ -24,6 +24,21 @@
 
 set -e
 
+usage() {
+    cat << 'EOF'
+Usage: init-session.sh [OPTIONS] [PROJECT NAME]
+
+Initialize task_plan.md, findings.md, and progress.md for a planning session.
+
+Options:
+  -t, --template TYPE  Use the default or analytics template.
+      --plan-dir       Create an isolated plan directory without a name.
+      --autonomous     Enable autonomous mode and plan attestation.
+      --gated          Enable autonomous mode with the completion gate.
+  -h, --help           Print this help and exit without changing files.
+EOF
+}
+
 TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
@@ -50,6 +65,10 @@ while [ $# -gt 0 ]; do
         --gated)
             MODE="gated"
             shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
             ;;
         *)
             if [ -z "$PROJECT_NAME" ]; then

--- a/.factory/skills/planning-with-files/scripts/init-session.sh
+++ b/.factory/skills/planning-with-files/scripts/init-session.sh
@@ -24,6 +24,21 @@
 
 set -e
 
+usage() {
+    cat << 'EOF'
+Usage: init-session.sh [OPTIONS] [PROJECT NAME]
+
+Initialize task_plan.md, findings.md, and progress.md for a planning session.
+
+Options:
+  -t, --template TYPE  Use the default or analytics template.
+      --plan-dir       Create an isolated plan directory without a name.
+      --autonomous     Enable autonomous mode and plan attestation.
+      --gated          Enable autonomous mode with the completion gate.
+  -h, --help           Print this help and exit without changing files.
+EOF
+}
+
 TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
@@ -50,6 +65,10 @@ while [ $# -gt 0 ]; do
         --gated)
             MODE="gated"
             shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
             ;;
         *)
             if [ -z "$PROJECT_NAME" ]; then

--- a/.gemini/skills/planning-with-files/scripts/init-session.sh
+++ b/.gemini/skills/planning-with-files/scripts/init-session.sh
@@ -24,6 +24,21 @@
 
 set -e
 
+usage() {
+    cat << 'EOF'
+Usage: init-session.sh [OPTIONS] [PROJECT NAME]
+
+Initialize task_plan.md, findings.md, and progress.md for a planning session.
+
+Options:
+  -t, --template TYPE  Use the default or analytics template.
+      --plan-dir       Create an isolated plan directory without a name.
+      --autonomous     Enable autonomous mode and plan attestation.
+      --gated          Enable autonomous mode with the completion gate.
+  -h, --help           Print this help and exit without changing files.
+EOF
+}
+
 TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
@@ -50,6 +65,10 @@ while [ $# -gt 0 ]; do
         --gated)
             MODE="gated"
             shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
             ;;
         *)
             if [ -z "$PROJECT_NAME" ]; then

--- a/.pi/skills/planning-with-files/scripts/init-session.sh
+++ b/.pi/skills/planning-with-files/scripts/init-session.sh
@@ -24,6 +24,21 @@
 
 set -e
 
+usage() {
+    cat << 'EOF'
+Usage: init-session.sh [OPTIONS] [PROJECT NAME]
+
+Initialize task_plan.md, findings.md, and progress.md for a planning session.
+
+Options:
+  -t, --template TYPE  Use the default or analytics template.
+      --plan-dir       Create an isolated plan directory without a name.
+      --autonomous     Enable autonomous mode and plan attestation.
+      --gated          Enable autonomous mode with the completion gate.
+  -h, --help           Print this help and exit without changing files.
+EOF
+}
+
 TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
@@ -50,6 +65,10 @@ while [ $# -gt 0 ]; do
         --gated)
             MODE="gated"
             shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
             ;;
         *)
             if [ -z "$PROJECT_NAME" ]; then

--- a/scripts/init-session.sh
+++ b/scripts/init-session.sh
@@ -24,6 +24,21 @@
 
 set -e
 
+usage() {
+    cat << 'EOF'
+Usage: init-session.sh [OPTIONS] [PROJECT NAME]
+
+Initialize task_plan.md, findings.md, and progress.md for a planning session.
+
+Options:
+  -t, --template TYPE  Use the default or analytics template.
+      --plan-dir       Create an isolated plan directory without a name.
+      --autonomous     Enable autonomous mode and plan attestation.
+      --gated          Enable autonomous mode with the completion gate.
+  -h, --help           Print this help and exit without changing files.
+EOF
+}
+
 TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
@@ -50,6 +65,10 @@ while [ $# -gt 0 ]; do
         --gated)
             MODE="gated"
             shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
             ;;
         *)
             if [ -z "$PROJECT_NAME" ]; then

--- a/skills/planning-with-files/scripts/init-session.sh
+++ b/skills/planning-with-files/scripts/init-session.sh
@@ -24,6 +24,21 @@
 
 set -e
 
+usage() {
+    cat << 'EOF'
+Usage: init-session.sh [OPTIONS] [PROJECT NAME]
+
+Initialize task_plan.md, findings.md, and progress.md for a planning session.
+
+Options:
+  -t, --template TYPE  Use the default or analytics template.
+      --plan-dir       Create an isolated plan directory without a name.
+      --autonomous     Enable autonomous mode and plan attestation.
+      --gated          Enable autonomous mode with the completion gate.
+  -h, --help           Print this help and exit without changing files.
+EOF
+}
+
 TEMPLATE="default"
 PROJECT_NAME=""
 USE_PLAN_DIR=0
@@ -50,6 +65,10 @@ while [ $# -gt 0 ]; do
         --gated)
             MODE="gated"
             shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
             ;;
         *)
             if [ -z "$PROJECT_NAME" ]; then

--- a/tests/test_init_session_slug.py
+++ b/tests/test_init_session_slug.py
@@ -86,6 +86,15 @@ class InitSessionSlugTests(unittest.TestCase):
             self.assertEqual(1, len(dirs))
             self.assertTrue(re.match(rf"^{today}-untitled-[a-z0-9]+$", dirs[0].name))
 
+    def test_help_flags_print_usage_without_mutating_planning_state(self) -> None:
+        for flag in ("-h", "--help"):
+            with self.subTest(flag=flag), tempfile.TemporaryDirectory() as tmp:
+                root = Path(tmp)
+                result = self.run_init(root, flag)
+                self.assertEqual(0, result.returncode, result.stderr)
+                self.assertIn("Usage:", result.stdout)
+                self.assertEqual([], list(root.iterdir()))
+
     def test_template_flag_still_works_in_legacy_mode(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
What changed:

- Add -h and --help handling before plan initialization.
- Print POSIX-shell usage and exit successfully without touching the filesystem.
- Sync the canonical script to supported IDE mirrors.
- Add a regression test covering both help flags and an empty output directory.

Why:

init-session.sh previously treated help flags as project names. A help query created a dated plan and overwrote .planning/.active_plan, which could redirect later hooks in a shared working directory.

How tested:

- Untouched baseline: 415 passed, 31 skipped, 490 subtests passed.
- Focused regression before fix: 2 subtests failed and reproduced the filesystem mutation.
- Focused regression after fix: 1 passed, 2 subtests passed.
- Full suite after fix: 416 passed, 31 skipped, 492 subtests passed.
- python3 scripts/sync-ide-folders.py --verify: all IDE folders in sync.
- git diff --check: clean.

Known limitations:

- This PR intentionally does not change unknown-option handling or downstream Spec Guard behavior.

Closes #232